### PR TITLE
config(validation): Allows users to disable validatedComponent in the build

### DIFF
--- a/addon/-debug/validated-component.js
+++ b/addon/-debug/validated-component.js
@@ -1,8 +1,6 @@
 import Component from '@ember/component';
-import { getWithDefault } from '@ember/object';
 import { assert } from '@ember/debug';
 
-import config from 'ember-get-config';
 import {
   GTE_EMBER_1_13,
   HAS_MODERN_FACTORY_INJECTIONS
@@ -18,7 +16,7 @@ const whitelist = {
   class: true
 };
 
-if (GTE_EMBER_1_13 && getWithDefault(config, 'emberArgumentDecorators.requireComponentArguments', true)) {
+if (GTE_EMBER_1_13) {
   validatedComponent = Component.extend()
 
   validatedComponent.reopenClass({

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
   },
 
   treeForAddon(tree) {
-    const filteredTree = !(isProductionEnv() && !this.disableCodeStripping) ? tree : new Funnel(tree, {
+    const filteredTree = !(isProductionEnv() && !this.options.disableCodeStripping) ? tree : new Funnel(tree, {
       exclude: [
         '-debug',
         'errors.js',
@@ -52,7 +52,7 @@ module.exports = {
 
     opts.loose = true;
 
-    if (isProductionEnv() && !this.disableCodeStripping) {
+    if (isProductionEnv() && !this.options.disableCodeStripping) {
       opts.plugins.push(
         [FilterImports, {
           imports: {
@@ -75,7 +75,7 @@ module.exports = {
 
     let parentOptions = this._getParentOptions();
 
-    this.disableCodeStripping = parentOptions.emberArgumentDecorators && parentOptions.emberArgumentDecorators.disableCodeStripping
+    this.options = parentOptions.emberArgumentDecorators || {};
 
     this._setupBabelOptions();
 
@@ -89,7 +89,7 @@ module.exports = {
         // Create and pull off babel plugins
         let plugins = parentOptions.babel.plugins = parentOptions.babel.plugins || [];
 
-        if (isProductionEnv() && !this.disableCodeStripping) {
+        if (isProductionEnv() && !this.options.disableCodeStripping) {
           plugins.push(
             [FilterImports, {
               imports: {
@@ -112,7 +112,7 @@ module.exports = {
               }
             }]
           );
-        } else {
+        } else if (!this.options.disableValidatedComponent) {
           plugins.push([ValidatedComponentTransform]);
         }
       } else {

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
   },
 
   treeForAddon(tree) {
-    const filteredTree = !(isProductionEnv() && !this.options.disableCodeStripping) ? tree : new Funnel(tree, {
+    const filteredTree = !(isProductionEnv() && !this.addonOptions.disableCodeStripping) ? tree : new Funnel(tree, {
       exclude: [
         '-debug',
         'errors.js',
@@ -52,7 +52,7 @@ module.exports = {
 
     opts.loose = true;
 
-    if (isProductionEnv() && !this.options.disableCodeStripping) {
+    if (isProductionEnv() && !this.addonOptions.disableCodeStripping) {
       opts.plugins.push(
         [FilterImports, {
           imports: {
@@ -75,7 +75,7 @@ module.exports = {
 
     let parentOptions = this._getParentOptions();
 
-    this.options = parentOptions.emberArgumentDecorators || {};
+    this.addonOptions = parentOptions.emberArgumentDecorators || {};
 
     this._setupBabelOptions();
 
@@ -89,7 +89,7 @@ module.exports = {
         // Create and pull off babel plugins
         let plugins = parentOptions.babel.plugins = parentOptions.babel.plugins || [];
 
-        if (isProductionEnv() && !this.options.disableCodeStripping) {
+        if (isProductionEnv() && !this.addonOptions.disableCodeStripping) {
           plugins.push(
             [FilterImports, {
               imports: {
@@ -112,7 +112,7 @@ module.exports = {
               }
             }]
           );
-        } else if (!this.options.disableValidatedComponent) {
+        } else if (!this.addonOptions.disableValidatedComponent) {
           plugins.push([ValidatedComponentTransform]);
         }
       } else {


### PR DESCRIPTION
The `ValidatedComponent` class works by extending normal Components and overriding `create` to check the `attrs` hash that's pushed into the component. We compare the keys of the hash against defined arguments, and if someone has pushed a value that was not defined as an argument then it throws an error.

Originally I reopened the Component class as a whole, but the immediate issue with this was that it would affect all components - not just the ones in the user's app, but any addons they were using as well. We could also implement a class decorator like `@validated` or something, or even try to use the argument decorators to extend the class if they are used, but my goal was zero-cost and automatic validation - if you drop-in `ember-argument-decorators` to your app/addon, you should immediately get the benefit of strong argument validations on all components you define.

The custom babel transform included in `lib` does this by replacing all imports of `@ember/component` with `ember-argument-decorators/-debug/validated-component`. This works pretty well, but as you can see from this PR the config would turning validation on/off was still based on the global app config - if a single addon/app were to not include argument validations for _some_ of their components, we'd have to turn it off for all of them. Moving this config option into `ember-cli` fixes this issue by enabling it on a per-addon/app basis.