### PR TITLE
feat(validations): Allow dynamic bindings

### DIFF
--- a/addon/-debug/validated-component.js
+++ b/addon/-debug/validated-component.js
@@ -21,10 +21,13 @@ if (GTE_EMBER_1_13) {
 
   validatedComponent.reopenClass({
     create(props) {
+      // First create the instance to realize any dynamically added bindings or fields
+      const instance = this._super(...arguments);
+
       const prototype = HAS_MODERN_FACTORY_INJECTIONS ? this.prototype : this.__super__;
       const validations = validationsFor(prototype);
-      const attributes = (prototype.attributeBindings || []);
-      const classNames = (prototype.classNameBindings || []).map((binding) => binding.split(':')[0]);
+      const attributes = (instance.attributeBindings || []);
+      const classNames = (instance.classNameBindings || []).map((binding) => binding.split(':')[0]);
 
       for (let key in props.attrs) {
         const isValidArgOrAttr =
@@ -39,7 +42,7 @@ if (GTE_EMBER_1_13) {
         );
       }
 
-      return this._super(...arguments);
+      return instance;
     }
   });
 } else {

--- a/tests/unit/-debug/component/validated-component-test.js
+++ b/tests/unit/-debug/component/validated-component-test.js
@@ -71,4 +71,21 @@ if (GTE_EMBER_1_13) {
 
     this.render(hbs`{{foo-component foo=123}}`);
   });
+
+  test('does not assert on classNames or attributes which are defined dynamically', function(assert) {
+    assert.expect(0);
+
+    class FooComponent extends Component {
+      constructor() {
+        super(...arguments);
+
+        this.attributeBindings = ['data-test'];
+        this.classNameBindings = ['foo']
+      }
+    }
+
+    this.register('component:foo-component', FooComponent);
+
+    this.render(hbs`{{foo-component foo=123 data-test=true}}`);
+  });
 }


### PR DESCRIPTION
Addons like ember-test-selectors dynamically add bindings when components initialize themselves. By running validations after the components have initialized, we can allow everything to Just Work.