### PR TITLE
bugfix(meta): Fixes both meta maps inheritance chains

### DIFF
--- a/addon/-debug/utils/validation-decorator.js
+++ b/addon/-debug/utils/validation-decorator.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { computed, get } from '@ember/object';
 
-import { validationsFor, validationsForKey } from '@ember-decorators/utils/debug';
+import { getValidationsFor, getValidationsForKey } from './validations-for';
 
 import { SUPPORTS_NEW_COMPUTED } from 'ember-compatibility-helpers';
 
@@ -41,7 +41,7 @@ EmberObject.reopenClass({
 
     const constructor = this;
     const prototype = Object.getPrototypeOf(instance);
-    const validations = validationsFor(prototype);
+    const validations = getValidationsFor(prototype);
 
     for (let key in validations) {
       const {
@@ -96,7 +96,7 @@ EmberObject.reopenClass({
 
 export default function validationDecorator(fn) {
   return function(target, key, desc) {
-    const validations = validationsForKey(target, key);
+    const validations = getValidationsForKey(target, key);
 
     // always ensure the property is writeable, doesn't make sense otherwise (babel bug?)
     desc.writable = true;

--- a/addon/-debug/utils/validations-for.js
+++ b/addon/-debug/utils/validations-for.js
@@ -1,0 +1,56 @@
+const validationMetaMap = new WeakMap();
+
+class FieldValidations {
+  constructor(parentValidations = null) {
+    if (parentValidations === null) {
+      this.isRequired = false;
+      this.isImmutable = false;
+      this.isArgument = false;
+      this.typeRequired = false;
+
+      this.typeValidators = [];
+    } else {
+      const {
+        isRequired,
+        isImmutable,
+        isArgument,
+        typeRequired,
+        typeValidators
+      } = parentValidations;
+
+      this.isRequired = isRequired;
+      this.isImmutable = isImmutable;
+      this.isArgument = isArgument;
+      this.typeRequired = typeRequired;
+
+      this.typeValidators = typeValidators.slice();
+    }
+  }
+}
+
+export function getValidationsFor(target) {
+  // Reached the root of the prototype chain
+  if (target === null) return Object;
+
+  return validationMetaMap.get(target) || getValidationsFor(Object.getPrototypeOf(target));
+}
+
+export function getOrCreateValidationsFor(target) {
+  if (!validationMetaMap.has(target)) {
+    const parentMeta = getValidationsFor(Object.getPrototypeOf(target));
+    validationMetaMap.set(target, Object.create(parentMeta || Object));
+  }
+
+  return validationMetaMap.get(target);
+}
+
+export function getValidationsForKey(target, key) {
+  const validations = getOrCreateValidationsFor(target);
+
+  if (!validations.hasOwnProperty(key)) {
+    const parentValidations = validations[key];
+    validations[key] = new FieldValidations(parentValidations);
+  }
+
+  return validations[key];
+}

--- a/addon/-debug/validated-component.js
+++ b/addon/-debug/validated-component.js
@@ -1,12 +1,14 @@
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
 
+import './utils/validation-decorator';
+
 import {
   GTE_EMBER_1_13,
   HAS_MODERN_FACTORY_INJECTIONS
 } from 'ember-compatibility-helpers';
 
-import { validationsFor } from '@ember-decorators/utils/debug';
+import { getValidationsFor } from './utils/validations-for';
 
 let validatedComponent;
 
@@ -28,7 +30,7 @@ if (GTE_EMBER_1_13) {
       const instance = this._super(...arguments);
 
       const prototype = HAS_MODERN_FACTORY_INJECTIONS ? this.prototype : this.__super__;
-      const validations = validationsFor(prototype);
+      const validations = getValidationsFor(prototype) || {};
       const attributes = (instance.attributeBindings || []);
       const classNames = (instance.classNameBindings || []).map((binding) => binding.split(':')[0]);
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -8,9 +8,9 @@ export { immutable, required, type } from 'ember-argument-decorators/-debug';
 
 const initializersMap = new WeakMap();
 
-function createInitializersFor(target) {
+function getOrCreateInitializersFor(target) {
   if (!initializersMap.has(target)) {
-    const parentInitializers = initializersMap.get(Object.getPrototypeOf(target));
+    const parentInitializers = getInitializersFor(Object.getPrototypeOf(target));
     initializersMap.set(target, Object.create(parentInitializers || null));
   }
 
@@ -18,6 +18,9 @@ function createInitializersFor(target) {
 }
 
 function getInitializersFor(target) {
+  // Reached the root of the prototype chain
+  if (target === null) return target;
+
   return initializersMap.get(target) || getInitializersFor(Object.getPrototypeOf(target));
 }
 
@@ -33,7 +36,7 @@ let argument = function(target, key, desc, validations) {
 
   if (desc.initializer === null) return;
 
-  const initializers = createInitializersFor(target);
+  const initializers = getOrCreateInitializersFor(target);
   initializers[key] = desc.initializer;
 
   desc.initializer = function() {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@ember-decorators/utils": "~0.1.0",
     "babel-plugin-filter-imports": "^1.1.0",
     "broccoli-funnel": "^2.0.1",
     "ember-cli-babel": "^6.3.0",

--- a/tests/unit/-debug/type-test.js
+++ b/tests/unit/-debug/type-test.js
@@ -57,6 +57,32 @@ test('it throws if an incorrect value is provided', function(assert) {
   }, /bar expected value of type string, but received: 2/);
 });
 
+test('it works with the class hierarchy', function(assert) {
+  class Foo extends EmberObject {
+    @type('string')
+    @argument
+    prop;
+  }
+
+  class Bar extends Foo {}
+
+  class Baz extends Bar {}
+
+  class Quix extends Baz {
+    @type('number')
+    @argument
+    anotherProp = 2;
+  }
+
+  assert.throws(() => {
+    Quix.create({ prop: 2 });
+  }, /prop expected value of type string, but received: 2/);
+
+  assert.throws(() => {
+    Quix.create({ anotherProp: 'val' });
+  }, /anotherProp expected value of type number, but received: val/);
+});
+
 test('it throws if an incorrect default default value is provided', function(assert) {
   assert.throws(() => {
     // no default

--- a/tests/unit/argument-test.js
+++ b/tests/unit/argument-test.js
@@ -66,17 +66,21 @@ test('it works with the ES class hierarchy up the prototype chain', function(ass
     prop = 1;
   }
 
-  class Bar extends Foo {
+  class Bar extends Foo {}
+
+  class Baz extends Bar {}
+
+  class Quix extends Baz {
+    @argument
+    anotherProp = 2;
   }
 
-  class Baz extends Bar {
-  }
+  const quix = Quix.create({});
+  const quixWithValues = Baz.create({ prop: 7, anotherProp: 7 });
 
-  const baz = Baz.create({});
+  assert.equal(quix.get('prop'), 1, 'argument default is set');
+  assert.equal(quix.get('anotherProp'), 2, 'argument default is set');
 
-  const bazWithValues = Baz.create({ prop: 7 });
-
-  assert.equal(baz.get('prop'), 1, 'argument default is set');
-
-  assert.equal(bazWithValues.get('prop'), 7, 'subclass argument default can be overriden');
+  assert.equal(quixWithValues.get('prop'), 7, 'subclass argument default can be overriden');
+  assert.equal(quixWithValues.get('prop'), 7, 'subclass argument default can be overriden');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,6 @@
 # yarn lockfile v1
 
 
-"@ember-decorators/utils@~0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-0.1.0.tgz#9b47965520b5b43643fb00441e2b340130d28157"
-  dependencies:
-    babel-plugin-filter-imports "^1.0.4"
-    broccoli-funnel "^2.0.1"
-    ember-cli-babel "^6.3.0"
-
 "@glimmer/compiler@^0.25.3":
   version "0.25.3"
   resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.25.3.tgz#25eb06394f3ba1c1fae5af25c9cf7deb2c11ef4e"
@@ -652,13 +644,6 @@ babel-plugin-feature-flags@^0.3.1:
 babel-plugin-filter-imports@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
-
-babel-plugin-filter-imports@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-1.0.4.tgz#356aea4f8d3ec5a2cc69d7c916daeb8f554c6f7c"
-  dependencies:
-    babel-types "^6.26.0"
-    lodash "^4.17.4"
 
 babel-plugin-filter-imports@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Actually fixes meta map inheritance, and pulls the validation meta map back into this lib from `@ember-decorators/utils`.