### PR TITLE
feature(validators): Allows users to pass null and undefined directly to @type

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,16 @@ Primitive types include:
 * `symbol`
 * `null`
 * `undefined`
+* `NaN`
 
 Each of the above maps directly to their respective Javascript primitive types. In addition, there are
 several special primitives:
 
 * `any`: Any type of value
 * `action`: Union type of `string` and `function`. Use this to declare actions that the component sends
-* `class`: Any function that is specifically a class constructor
+* `class`: Any function that extends from Ember Object (we want to allow this to work with ES Classes in the future, stay tuned!)
+
+You can also pass `null` and `undefined` directly as types for convenience
 
 Type helpers include:
 
@@ -96,10 +99,10 @@ import Component from '@ember/component';
 import { type } from 'ember-argument-decorators';
 
 export default class ExampleComponent extends Component {
-  @type('string')
+  @type(null, 'string')
   arg = 'default';
 
-  @type(Date)
+  @type(undefined, Date)
   foo;
 
   @type(unionOf('string', 'number', Date))

--- a/addon/-debug/utils/validators.js
+++ b/addon/-debug/utils/validators.js
@@ -30,7 +30,9 @@ export function makeValidator(desc, fn) {
 }
 
 export function resolveValidator(type) {
-  if (type.isValidator === true) {
+  if (type === null || type === undefined) {
+    return type === null ? primitiveTypeValidators.null : primitiveTypeValidators.undefined;
+  } else if (type.isValidator === true) {
     return type;
   } else if (typeof type === 'function') {
     return instanceOf(type);
@@ -39,6 +41,6 @@ export function resolveValidator(type) {
 
     return primitiveTypeValidators[type];
   } else {
-    assert(`Types must either be a primitive type string, a class, or a validator, received: ${type}`, false);
+    assert(`Types must either be a primitive type string, class, validator, or null or undefined, received: ${type}`, false);
   }
 }

--- a/tests/unit/-debug/type-test.js
+++ b/tests/unit/-debug/type-test.js
@@ -172,7 +172,7 @@ test('it requires primitive types or classes', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, a class, or a validator, received: 2/);
+  }, /Types must either be a primitive type string, class, validator, or null or undefined, received: 2/);
 
   assert.throws(() => {
     class Foo extends EmberObject {
@@ -182,7 +182,7 @@ test('it requires primitive types or classes', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, a class, or a validator, received: true/);
+  }, /Types must either be a primitive type string, class, validator, or null or undefined, received: true/);
 
   assert.throws(() => {
     class Foo extends EmberObject {
@@ -192,7 +192,7 @@ test('it requires primitive types or classes', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, a class, or a validator, received: \[object Object\]/);
+  }, /Types must either be a primitive type string, class, validator, or null or undefined, received: \[object Object\]/);
 
   assert.throws(() => {
     class Foo extends EmberObject {
@@ -202,7 +202,7 @@ test('it requires primitive types or classes', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, a class, or a validator, received:/);
+  }, /Types must either be a primitive type string, class, validator, or null or undefined, received:/);
 });
 
 test('it throws if types are required on an argument', function(assert) {

--- a/tests/unit/-debug/types/primitives-test.js
+++ b/tests/unit/-debug/types/primitives-test.js
@@ -50,5 +50,8 @@ primitiveTypeTest('NaN');
 primitiveTypeTest('null');
 primitiveTypeTest('undefined');
 
+primitiveTypeTest(null, ['null']);
+primitiveTypeTest(undefined, ['undefined']);
+
 primitiveTypeTest('action', ['string', 'function']);
 primitiveTypeTest('any', Object.keys(primitives));

--- a/tests/unit/-debug/types/union-of-test.js
+++ b/tests/unit/-debug/types/union-of-test.js
@@ -55,7 +55,7 @@ test('it requires primitive types or classes', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, a class, or a validator, received: 2/);
+  }, /Types must either be a primitive type string, class, validator, or null or undefined, received: 2/);
 
   assert.throws(() => {
     class Foo extends EmberObject {
@@ -65,7 +65,7 @@ test('it requires primitive types or classes', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, a class, or a validator, received: true/);
+  }, /Types must either be a primitive type string, class, validator, or null or undefined, received: true/);
 
   assert.throws(() => {
     class Foo extends EmberObject {
@@ -75,7 +75,7 @@ test('it requires primitive types or classes', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, a class, or a validator, received: \[object Object\]/);
+  }, /Types must either be a primitive type string, class, validator, or null or undefined, received: \[object Object\]/);
 
   assert.throws(() => {
     class Foo extends EmberObject {
@@ -85,7 +85,7 @@ test('it requires primitive types or classes', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, a class, or a validator, received:/);
+  }, /Types must either be a primitive type string, class, validator, or null or undefined, received:/);
 });
 
 test('it throws if incorrect number of items passed in', function(assert) {


### PR DESCRIPTION
Writing out type declarations, I find it's pretty natural to use `null` or `undefined` directly, especially in certain unions alongside classes:

```js
@type(unionOf(null, 'string', Element))
```

This PR allows this syntax optionally. Strings can still be used.