### PR TITLE
refactor(rename): Renames to @ember-decorators/argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @ember-decorators/arguments
+# @ember-decorators/argument
 
 This addon provides a set of decorators that allow you to declaratively specify argument and field
 types and properties, such as mutability. It includes:
@@ -12,7 +12,7 @@ which allow you to specify runtime validations for fields
 
 ```js
 import Component from '@ember/component';
-import { argument, type, immutable } from '@ember-decorators/arguments';
+import { argument, type, immutable } from '@ember-decorators/argument';
 
 export default class ExampleComponent extends Component {
   @argument
@@ -38,7 +38,7 @@ a config option in `ember-cli-build`.
 
 ```js
 import Component from '@ember/component';
-import { argument } from '@ember-decorators/arguments';
+import { argument } from '@ember-decorators/argument';
 
 export default class ExampleComponent extends Component {
   @argument
@@ -96,7 +96,7 @@ proper types, so it is valid for all objects which fulfill the shape (structural
 
 ```js
 import Component from '@ember/component';
-import { type } from '@ember-decorators/arguments';
+import { type } from '@ember-decorators/argument';
 
 export default class ExampleComponent extends Component {
   @type(null, 'string')
@@ -128,7 +128,7 @@ so the value can be provided by a subclass.
 
 ```js
 import Component from '@ember/component';
-import { argument, required } from '@ember-decorators/arguments';
+import { argument, required } from '@ember-decorators/argument';
 
 export default class ExampleComponent extends Component {
   @required
@@ -151,7 +151,7 @@ changed or overridden by subclasses.
 
 ```js
 import EmberObject from '@ember/object';
-import { immutable } from '@ember-decorators/arguments';
+import { immutable } from '@ember-decorators/argument';
 
 class ExampleClass extends EmberObject {
   @immutable
@@ -170,7 +170,7 @@ base class field and decorator babel transforms
 
 ```bash
 ember install ember-decorators
-ember install @ember-decorators/arguments
+ember install @ember-decorators/argument
 ```
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ember-argument-decorators
+# @ember-decorators/arguments
 
 This addon provides a set of decorators that allow you to declaratively specify argument and field
 types and properties, such as mutability. It includes:
@@ -12,7 +12,7 @@ which allow you to specify runtime validations for fields
 
 ```js
 import Component from '@ember/component';
-import { argument, type, immutable } from 'ember-argument-decorators';
+import { argument, type, immutable } from '@ember-decorators/arguments';
 
 export default class ExampleComponent extends Component {
   @argument
@@ -38,7 +38,7 @@ a config option in `ember-cli-build`.
 
 ```js
 import Component from '@ember/component';
-import { argument } from 'ember-argument-decorators';
+import { argument } from '@ember-decorators/arguments';
 
 export default class ExampleComponent extends Component {
   @argument
@@ -96,7 +96,7 @@ proper types, so it is valid for all objects which fulfill the shape (structural
 
 ```js
 import Component from '@ember/component';
-import { type } from 'ember-argument-decorators';
+import { type } from '@ember-decorators/arguments';
 
 export default class ExampleComponent extends Component {
   @type(null, 'string')
@@ -128,7 +128,7 @@ so the value can be provided by a subclass.
 
 ```js
 import Component from '@ember/component';
-import { argument, required } from 'ember-argument-decorators';
+import { argument, required } from '@ember-decorators/arguments';
 
 export default class ExampleComponent extends Component {
   @required
@@ -151,7 +151,7 @@ changed or overridden by subclasses.
 
 ```js
 import EmberObject from '@ember/object';
-import { immutable } from 'ember-argument-decorators';
+import { immutable } from '@ember-decorators/arguments';
 
 class ExampleClass extends EmberObject {
   @immutable
@@ -170,7 +170,7 @@ base class field and decorator babel transforms
 
 ```bash
 ember install ember-decorators
-ember install ember-argument-decorators
+ember install @ember-decorators/arguments
 ```
 
 ## Running

--- a/addon/errors.js
+++ b/addon/errors.js
@@ -1,3 +1,3 @@
-export { MutabilityError as MutabilityError } from '@ember-decorators/arguments/-debug';
-export { RequiredFieldError as RequiredFieldError } from '@ember-decorators/arguments/-debug';
-export { TypeError as TypeError } from '@ember-decorators/arguments/-debug';
+export { MutabilityError as MutabilityError } from '@ember-decorators/argument/-debug';
+export { RequiredFieldError as RequiredFieldError } from '@ember-decorators/argument/-debug';
+export { TypeError as TypeError } from '@ember-decorators/argument/-debug';

--- a/addon/errors.js
+++ b/addon/errors.js
@@ -1,3 +1,3 @@
-export { MutabilityError as MutabilityError } from 'ember-argument-decorators/-debug';
-export { RequiredFieldError as RequiredFieldError } from 'ember-argument-decorators/-debug';
-export { TypeError as TypeError } from 'ember-argument-decorators/-debug';
+export { MutabilityError as MutabilityError } from '@ember-decorators/arguments/-debug';
+export { RequiredFieldError as RequiredFieldError } from '@ember-decorators/arguments/-debug';
+export { TypeError as TypeError } from '@ember-decorators/arguments/-debug';

--- a/addon/index.js
+++ b/addon/index.js
@@ -2,9 +2,9 @@ import { DEBUG } from '@glimmer/env';
 import { getWithDefault } from '@ember/object';
 import config from 'ember-get-config';
 
-import { validationDecorator } from 'ember-argument-decorators/-debug';
+import { validationDecorator } from '@ember-decorators/arguments/-debug';
 
-export { immutable, required, type } from 'ember-argument-decorators/-debug';
+export { immutable, required, type } from '@ember-decorators/arguments/-debug';
 
 const initializersMap = new WeakMap();
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -2,9 +2,9 @@ import { DEBUG } from '@glimmer/env';
 import { getWithDefault } from '@ember/object';
 import config from 'ember-get-config';
 
-import { validationDecorator } from '@ember-decorators/arguments/-debug';
+import { validationDecorator } from '@ember-decorators/argument/-debug';
 
-export { immutable, required, type } from '@ember-decorators/arguments/-debug';
+export { immutable, required, type } from '@ember-decorators/argument/-debug';
 
 const initializersMap = new WeakMap();
 

--- a/addon/types.js
+++ b/addon/types.js
@@ -1,4 +1,4 @@
-export { arrayOf as arrayOf } from 'ember-argument-decorators/-debug';
-export { shapeOf as shapeOf } from 'ember-argument-decorators/-debug';
-export { subclassOf as subclassOf } from 'ember-argument-decorators/-debug';
-export { unionOf as unionOf } from 'ember-argument-decorators/-debug';
+export { arrayOf as arrayOf } from '@ember-decorators/arguments/-debug';
+export { shapeOf as shapeOf } from '@ember-decorators/arguments/-debug';
+export { subclassOf as subclassOf } from '@ember-decorators/arguments/-debug';
+export { unionOf as unionOf } from '@ember-decorators/arguments/-debug';

--- a/addon/types.js
+++ b/addon/types.js
@@ -1,4 +1,4 @@
-export { arrayOf as arrayOf } from '@ember-decorators/arguments/-debug';
-export { shapeOf as shapeOf } from '@ember-decorators/arguments/-debug';
-export { subclassOf as subclassOf } from '@ember-decorators/arguments/-debug';
-export { unionOf as unionOf } from '@ember-decorators/arguments/-debug';
+export { arrayOf as arrayOf } from '@ember-decorators/argument/-debug';
+export { shapeOf as shapeOf } from '@ember-decorators/argument/-debug';
+export { subclassOf as subclassOf } from '@ember-decorators/argument/-debug';
+export { unionOf as unionOf } from '@ember-decorators/argument/-debug';

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function isProductionEnv() {
 }
 
 module.exports = {
-  name: '@ember-decorators/arguments',
+  name: '@ember-decorators/argument',
 
   _getParentOptions() {
     let options;
@@ -56,7 +56,7 @@ module.exports = {
       opts.plugins.push(
         [FilterImports, {
           imports: {
-            '@ember-decorators/arguments/-debug': [
+            '@ember-decorators/argument/-debug': [
               'immutable',
               'required',
               'type',
@@ -93,18 +93,18 @@ module.exports = {
           plugins.push(
             [FilterImports, {
               imports: {
-                '@ember-decorators/arguments/types': [
+                '@ember-decorators/argument/types': [
                   'arrayOf',
                   'shapeOf',
                   'subclassOf',
                   'unionOf'
                 ],
-                '@ember-decorators/arguments': [
+                '@ember-decorators/argument': [
                   'type',
                   'required',
                   'immutable'
                 ],
-                '@ember-decorators/arguments/errors': [
+                '@ember-decorators/argument/errors': [
                   'MutabilityError',
                   'RequiredFieldError',
                   'TypeError'
@@ -117,7 +117,7 @@ module.exports = {
         }
       } else {
         app.project.ui.writeWarnLine(
-          '@ember-decorators/arguments: You are using an unsupported ember-cli-babel version,' +
+          '@ember-decorators/argument: You are using an unsupported ember-cli-babel version,' +
           'decorators will not be stripped automatically'
         );
       }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function isProductionEnv() {
 }
 
 module.exports = {
-  name: 'ember-argument-decorators',
+  name: '@ember-decorators/arguments',
 
   _getParentOptions() {
     let options;
@@ -56,7 +56,7 @@ module.exports = {
       opts.plugins.push(
         [FilterImports, {
           imports: {
-            'ember-argument-decorators/-debug': [
+            '@ember-decorators/arguments/-debug': [
               'immutable',
               'required',
               'type',
@@ -93,18 +93,18 @@ module.exports = {
           plugins.push(
             [FilterImports, {
               imports: {
-                'ember-argument-decorators/types': [
+                '@ember-decorators/arguments/types': [
                   'arrayOf',
                   'shapeOf',
                   'subclassOf',
                   'unionOf'
                 ],
-                'ember-argument-decorators': [
+                '@ember-decorators/arguments': [
                   'type',
                   'required',
                   'immutable'
                 ],
-                'ember-argument-decorators/errors': [
+                '@ember-decorators/arguments/errors': [
                   'MutabilityError',
                   'RequiredFieldError',
                   'TypeError'
@@ -117,8 +117,8 @@ module.exports = {
         }
       } else {
         app.project.ui.writeWarnLine(
-          'ember-legacy-class-transform: You are using an unsupported ember-cli-babel version,' +
-          'legacy class constructor transform will not be included automatically'
+          '@ember-decorators/arguments: You are using an unsupported ember-cli-babel version,' +
+          'decorators will not be stripped automatically'
         );
       }
 

--- a/lib/validated-component-transform/index.js
+++ b/lib/validated-component-transform/index.js
@@ -12,7 +12,7 @@ function covertValidateComponents(babel) {
           path.replaceWith(
             t.importDeclaration(
               [t.importDefaultSpecifier(t.identifier('Component'))],
-              t.stringLiteral('@ember-decorators/arguments/-debug/validated-component')
+              t.stringLiteral('@ember-decorators/argument/-debug/validated-component')
             )
           );
         }

--- a/lib/validated-component-transform/index.js
+++ b/lib/validated-component-transform/index.js
@@ -12,7 +12,7 @@ function covertValidateComponents(babel) {
           path.replaceWith(
             t.importDeclaration(
               [t.importDefaultSpecifier(t.identifier('Component'))],
-              t.stringLiteral('ember-argument-decorators/-debug/validated-component')
+              t.stringLiteral('@ember-decorators/arguments/-debug/validated-component')
             )
           );
         }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ember-decorators/arguments",
+  "name": "@ember-decorators/argument",
   "version": "0.6.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ember-argument-decorators",
-  "version": "0.6.1",
+  "name": "@ember-decorators/arguments",
+  "version": "0.6.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/tests/unit/-debug/component/validated-component-test.js
+++ b/tests/unit/-debug/component/validated-component-test.js
@@ -7,7 +7,7 @@ import { test } from 'qunit';
 
 import { GTE_EMBER_1_13 } from 'ember-compatibility-helpers';
 
-import { argument } from '@ember-decorators/arguments';
+import { argument } from '@ember-decorators/argument';
 import { attribute, className } from 'ember-decorators/component';
 
 if (GTE_EMBER_1_13) {

--- a/tests/unit/-debug/component/validated-component-test.js
+++ b/tests/unit/-debug/component/validated-component-test.js
@@ -7,7 +7,7 @@ import { test } from 'qunit';
 
 import { GTE_EMBER_1_13 } from 'ember-compatibility-helpers';
 
-import { argument } from 'ember-argument-decorators';
+import { argument } from '@ember-decorators/arguments';
 import { attribute, className } from 'ember-decorators/component';
 
 if (GTE_EMBER_1_13) {

--- a/tests/unit/-debug/immutable-test.js
+++ b/tests/unit/-debug/immutable-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, immutable, type } from '@ember-decorators/arguments';
+import { argument, immutable, type } from '@ember-decorators/argument';
 
 module('@immutable');
 

--- a/tests/unit/-debug/immutable-test.js
+++ b/tests/unit/-debug/immutable-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, immutable, type } from 'ember-argument-decorators';
+import { argument, immutable, type } from '@ember-decorators/arguments';
 
 module('@immutable');
 

--- a/tests/unit/-debug/required-test.js
+++ b/tests/unit/-debug/required-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, required } from 'ember-argument-decorators';
+import { argument, required } from '@ember-decorators/arguments';
 
 module('@required');
 

--- a/tests/unit/-debug/required-test.js
+++ b/tests/unit/-debug/required-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, required } from '@ember-decorators/arguments';
+import { argument, required } from '@ember-decorators/argument';
 
 module('@required');
 

--- a/tests/unit/-debug/type-test.js
+++ b/tests/unit/-debug/type-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, type } from '@ember-decorators/arguments';
+import { argument, type } from '@ember-decorators/argument';
 
 import config from 'ember-get-config';
 

--- a/tests/unit/-debug/type-test.js
+++ b/tests/unit/-debug/type-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, type } from 'ember-argument-decorators';
+import { argument, type } from '@ember-decorators/arguments';
 
 import config from 'ember-get-config';
 

--- a/tests/unit/-debug/types/array-of-test.js
+++ b/tests/unit/-debug/types/array-of-test.js
@@ -1,8 +1,8 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, type } from '@ember-decorators/arguments';
-import { arrayOf } from '@ember-decorators/arguments/types';
+import { argument, type } from '@ember-decorators/argument';
+import { arrayOf } from '@ember-decorators/argument/types';
 
 module('arrayOf');
 

--- a/tests/unit/-debug/types/array-of-test.js
+++ b/tests/unit/-debug/types/array-of-test.js
@@ -1,8 +1,8 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, type } from 'ember-argument-decorators';
-import { arrayOf } from 'ember-argument-decorators/types';
+import { argument, type } from '@ember-decorators/arguments';
+import { arrayOf } from '@ember-decorators/arguments/types';
 
 module('arrayOf');
 

--- a/tests/unit/-debug/types/primitives-test.js
+++ b/tests/unit/-debug/types/primitives-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { type } from '@ember-decorators/arguments';
+import { type } from '@ember-decorators/argument';
 
 module('@type primitives');
 

--- a/tests/unit/-debug/types/primitives-test.js
+++ b/tests/unit/-debug/types/primitives-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { type } from 'ember-argument-decorators';
+import { type } from '@ember-decorators/arguments';
 
 module('@type primitives');
 

--- a/tests/unit/-debug/types/shape-of-test.js
+++ b/tests/unit/-debug/types/shape-of-test.js
@@ -1,8 +1,8 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, type } from 'ember-argument-decorators';
-import { shapeOf } from 'ember-argument-decorators/types';
+import { argument, type } from '@ember-decorators/arguments';
+import { shapeOf } from '@ember-decorators/arguments/types';
 
 module('shapeOf');
 

--- a/tests/unit/-debug/types/shape-of-test.js
+++ b/tests/unit/-debug/types/shape-of-test.js
@@ -1,8 +1,8 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, type } from '@ember-decorators/arguments';
-import { shapeOf } from '@ember-decorators/arguments/types';
+import { argument, type } from '@ember-decorators/argument';
+import { shapeOf } from '@ember-decorators/argument/types';
 
 module('shapeOf');
 

--- a/tests/unit/-debug/types/subclass-of-test.js
+++ b/tests/unit/-debug/types/subclass-of-test.js
@@ -1,8 +1,8 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, type } from 'ember-argument-decorators';
-import { subclassOf } from 'ember-argument-decorators/types';
+import { argument, type } from '@ember-decorators/arguments';
+import { subclassOf } from '@ember-decorators/arguments/types';
 
 module('subclassOf');
 

--- a/tests/unit/-debug/types/subclass-of-test.js
+++ b/tests/unit/-debug/types/subclass-of-test.js
@@ -1,8 +1,8 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, type } from '@ember-decorators/arguments';
-import { subclassOf } from '@ember-decorators/arguments/types';
+import { argument, type } from '@ember-decorators/argument';
+import { subclassOf } from '@ember-decorators/argument/types';
 
 module('subclassOf');
 

--- a/tests/unit/-debug/types/union-of-test.js
+++ b/tests/unit/-debug/types/union-of-test.js
@@ -1,8 +1,8 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, type } from 'ember-argument-decorators';
-import { unionOf } from 'ember-argument-decorators/types';
+import { argument, type } from '@ember-decorators/arguments';
+import { unionOf } from '@ember-decorators/arguments/types';
 
 module('unionOf');
 

--- a/tests/unit/-debug/types/union-of-test.js
+++ b/tests/unit/-debug/types/union-of-test.js
@@ -1,8 +1,8 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument, type } from '@ember-decorators/arguments';
-import { unionOf } from '@ember-decorators/arguments/types';
+import { argument, type } from '@ember-decorators/argument';
+import { unionOf } from '@ember-decorators/argument/types';
 
 module('unionOf');
 

--- a/tests/unit/argument-test.js
+++ b/tests/unit/argument-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument } from '@ember-decorators/arguments';
+import { argument } from '@ember-decorators/argument';
 
 module('@argument');
 

--- a/tests/unit/argument-test.js
+++ b/tests/unit/argument-test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
-import { argument } from 'ember-argument-decorators';
+import { argument } from '@ember-decorators/arguments';
 
 module('@argument');
 

--- a/tests/unit/component/component-test.js
+++ b/tests/unit/component/component-test.js
@@ -5,7 +5,7 @@ import { moduleForComponent } from 'ember-qunit';
 import { test } from 'qunit';
 
 
-import { argument, type } from '@ember-decorators/arguments';
+import { argument, type } from '@ember-decorators/argument';
 import { find } from 'ember-native-dom-helpers';
 
 moduleForComponent('component', { integration: true });

--- a/tests/unit/component/component-test.js
+++ b/tests/unit/component/component-test.js
@@ -5,7 +5,7 @@ import { moduleForComponent } from 'ember-qunit';
 import { test } from 'qunit';
 
 
-import { argument, type } from 'ember-argument-decorators';
+import { argument, type } from '@ember-decorators/arguments';
 import { find } from 'ember-native-dom-helpers';
 
 moduleForComponent('component', { integration: true });


### PR DESCRIPTION
This PR renames the library to use the @ember-decorators scope. In the future, more libraries will be added to that scope, so this step will provide a cohesive API for the whole project