### PR TITLE
bugfix(validations): allows empty validations

### DIFF
--- a/addon/-debug/utils/validation-decorator.js
+++ b/addon/-debug/utils/validation-decorator.js
@@ -43,6 +43,10 @@ EmberObject.reopenClass({
     const prototype = Object.getPrototypeOf(instance);
     const validations = getValidationsFor(prototype);
 
+    if (!validations) {
+      return instance;
+    }
+
     for (let key in validations) {
       const {
         isImmutable,

--- a/addon/-debug/utils/validations-for.js
+++ b/addon/-debug/utils/validations-for.js
@@ -30,7 +30,7 @@ class FieldValidations {
 
 export function getValidationsFor(target) {
   // Reached the root of the prototype chain
-  if (target === null) return Object;
+  if (target === null) return;
 
   return validationMetaMap.get(target) || getValidationsFor(Object.getPrototypeOf(target));
 }

--- a/tests/unit/-debug/basic-test.js
+++ b/tests/unit/-debug/basic-test.js
@@ -1,0 +1,12 @@
+import EmberObject from '@ember/object';
+import { test, module } from 'qunit';
+
+module('basic tests');
+
+test('validations do not cause errors on unvalidated objects' , function(assert) {
+  class Foo extends EmberObject {}
+
+  const foo = Foo.create({ bar: 'baz' });
+
+  assert.equal(foo.get('bar'), 'baz', 'everything works correctly');
+});


### PR DESCRIPTION
Fixes a bug where empty validations would default to `Object` (the class) and attempt to validate against its properties. 