### PR TITLE
feat(argument): defaultIfUndefined option for @argument

### DIFF
--- a/addon/-debug/decorators/immutable.js
+++ b/addon/-debug/decorators/immutable.js
@@ -1,6 +1,6 @@
 import validationDecorator from '../utils/validation-decorator';
 
-const immutable = validationDecorator(function(target, key, desc, validations) {
+const immutable = validationDecorator(function(target, key, desc, options, validations) {
   validations.isImmutable = true;
 });
 

--- a/addon/-debug/decorators/required.js
+++ b/addon/-debug/decorators/required.js
@@ -1,6 +1,6 @@
 import validationDecorator from '../utils/validation-decorator';
 
-const required = validationDecorator(function(target, key, desc, validations) {
+const required = validationDecorator(function(target, key, desc, options, validations) {
   validations.isRequired = true;
 });
 

--- a/addon/-debug/decorators/type.js
+++ b/addon/-debug/decorators/type.js
@@ -8,7 +8,7 @@ export default function type(type) {
 
   const validator = resolveValidator(type);
 
-  return validationDecorator(function(target, key, desc, validations) {
+  return validationDecorator(function(target, key, desc, options, validations) {
     validations.typeValidators.push(validator);
   });
 }

--- a/addon/-debug/utils/validation-decorator.js
+++ b/addon/-debug/utils/validation-decorator.js
@@ -95,14 +95,14 @@ EmberObject.reopenClass({
 });
 
 export default function validationDecorator(fn) {
-  return function(target, key, desc) {
+  return function(target, key, desc, options) {
     const validations = getValidationsForKey(target, key);
 
     // always ensure the property is writeable, doesn't make sense otherwise (babel bug?)
     desc.writable = true;
     desc.configurable = true;
 
-    fn(target, key, desc, validations);
+    fn(target, key, desc, options, validations);
 
     if (desc.initializer === null) desc.initializer = undefined;
   }

--- a/addon/-private/initializers-meta.js
+++ b/addon/-private/initializers-meta.js
@@ -1,0 +1,17 @@
+const initializersMap = new WeakMap();
+
+export function getOrCreateInitializersFor(target) {
+  if (!initializersMap.has(target)) {
+    const parentInitializers = getInitializersFor(Object.getPrototypeOf(target));
+    initializersMap.set(target, Object.create(parentInitializers || null));
+  }
+
+  return initializersMap.get(target);
+}
+
+export function getInitializersFor(target) {
+  // Reached the root of the prototype chain
+  if (target === null) return target;
+
+  return initializersMap.get(target) || getInitializersFor(Object.getPrototypeOf(target));
+}

--- a/tests/unit/argument-test.js
+++ b/tests/unit/argument-test.js
@@ -84,3 +84,17 @@ test('it works with the ES class hierarchy up the prototype chain', function(ass
   assert.equal(quixWithValues.get('prop'), 7, 'subclass argument default can be overriden');
   assert.equal(quixWithValues.get('prop'), 7, 'subclass argument default can be overriden');
 });
+
+
+test('it works with defaultIfUndefined', function(assert) {
+  class Foo extends EmberObject {
+    @argument({ defaultIfUndefined: true })
+    bar = 1;
+  }
+
+  const foo = Foo.create({ bar: undefined });
+  const fooWithValues = Foo.create({ bar: 3 });
+
+  assert.equal(foo.get('bar'), 1, 'argument default gets set correctly');
+  assert.equal(fooWithValues.get('bar'), 3, 'argument default can be overriden');
+});


### PR DESCRIPTION
This PR adds a `defaultIfUndefined` option to the @argument decorator which modifies @argument's behavior. Normally, it will only initialize its value if the key does not yet exist on the object - this allows users to pass any value, including `undefined`, to objects and components and have it be set correctly. Adding this decorator will cause the default value to override the passed in value if the passed in value is `undefined`.

This is especially useful when creating wrapper components, where the user may wish to pass through certain arguments to a sub-component:

```
{{sub-component someArgument=someArgument}}
```

With just the `@argument` decorator, the user would have to provide a default value for `someArgument` in their component, otherwise it would be `undefined`.

Supercedes #18 