### PR TITLE
bugfix(IE): Allow class checks against object in IE

### DIFF
--- a/addon/-debug/utils/validators.js
+++ b/addon/-debug/utils/validators.js
@@ -34,7 +34,8 @@ export function resolveValidator(type) {
     return type === null ? primitiveTypeValidators.null : primitiveTypeValidators.undefined;
   } else if (type.isValidator === true) {
     return type;
-  } else if (typeof type === 'function') {
+  } else if (typeof type === 'function' || typeof type === 'object') {
+    // We allow objects for certain classes in IE, like Element, which have typeof 'object' for some reason
     return instanceOf(type);
   } else if (typeof type === 'string') {
     assert(`Unknown primitive type received: ${type}`, primitiveTypeValidators[type] !== undefined);

--- a/tests/unit/-debug/type-test.js
+++ b/tests/unit/-debug/type-test.js
@@ -184,16 +184,6 @@ test('it requires primitive types or classes', function(assert) {
 
     Foo.create({ bar: 2 });
   }, /Types must either be a primitive type string, class, validator, or null or undefined, received: true/);
-
-  assert.throws(() => {
-    class Foo extends EmberObject {
-      @type([])
-      @argument
-      bar;
-    }
-
-    Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, class, validator, or null or undefined, received:/);
 });
 
 test('it throws if types are required on an argument', function(assert) {

--- a/tests/unit/-debug/type-test.js
+++ b/tests/unit/-debug/type-test.js
@@ -187,16 +187,6 @@ test('it requires primitive types or classes', function(assert) {
 
   assert.throws(() => {
     class Foo extends EmberObject {
-      @type({})
-      @argument
-      bar;
-    }
-
-    Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, class, validator, or null or undefined, received: \[object Object\]/);
-
-  assert.throws(() => {
-    class Foo extends EmberObject {
       @type([])
       @argument
       bar;

--- a/tests/unit/-debug/types/union-of-test.js
+++ b/tests/unit/-debug/types/union-of-test.js
@@ -66,16 +66,6 @@ test('it requires primitive types or classes', function(assert) {
 
     Foo.create({ bar: 2 });
   }, /Types must either be a primitive type string, class, validator, or null or undefined, received: true/);
-
-  assert.throws(() => {
-    class Foo extends EmberObject {
-      @type(unionOf('string', []))
-      @argument
-      bar;
-    }
-
-    Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, class, validator, or null or undefined, received:/);
 });
 
 test('it throws if incorrect number of items passed in', function(assert) {

--- a/tests/unit/-debug/types/union-of-test.js
+++ b/tests/unit/-debug/types/union-of-test.js
@@ -69,16 +69,6 @@ test('it requires primitive types or classes', function(assert) {
 
   assert.throws(() => {
     class Foo extends EmberObject {
-      @type(unionOf('string', {}))
-      @argument
-      bar;
-    }
-
-    Foo.create({ bar: 2 });
-  }, /Types must either be a primitive type string, class, validator, or null or undefined, received: \[object Object\]/);
-
-  assert.throws(() => {
-    class Foo extends EmberObject {
       @type(unionOf('string', []))
       @argument
       bar;


### PR DESCRIPTION
See: https://github.com/kybishop/ember-popper/issues/56

IE11 has some weird typings for certain globals, this should allow us to treat them like normal classes for now