### PR TITLE
bugfix(validations): Prevent prototype extensions on validations

### DIFF
--- a/addon/-debug/utils/validations-for.js
+++ b/addon/-debug/utils/validations-for.js
@@ -38,7 +38,7 @@ export function getValidationsFor(target) {
 export function getOrCreateValidationsFor(target) {
   if (!validationMetaMap.has(target)) {
     const parentMeta = getValidationsFor(Object.getPrototypeOf(target));
-    validationMetaMap.set(target, Object.create(parentMeta || Object));
+    validationMetaMap.set(target, Object.create(parentMeta || null));
   }
 
   return validationMetaMap.get(target);
@@ -47,7 +47,7 @@ export function getOrCreateValidationsFor(target) {
 export function getValidationsForKey(target, key) {
   const validations = getOrCreateValidationsFor(target);
 
-  if (!validations.hasOwnProperty(key)) {
+  if (!Object.hasOwnProperty.call(validations, key)) {
     const parentValidations = validations[key];
     validations[key] = new FieldValidations(parentValidations);
   }


### PR DESCRIPTION
It seems that when prototype extensions are enabled they will also be enumerable properties on objects which have a prototype. Removing the prototype from validations prevents this from being an issue.