### PR TITLE
feat(config): ignore components without validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ You can tweak the following settings in your `config/environment.js` under the `
 
 If enabled, requires you to also specify a [`@type`](#type) for every [`@argument`](#argument).
 
+**Note**: Enabling this option breaks addons that use @ember-decorators/argument, but chose to not specify types for their arguments. See #29 for more information.
+
 ### `ignoreComponentsWithoutValidations`
 
 **Type**: `Boolean` | **Default**: `false`

--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ ember install ember-decorators
 ember install @ember-decorators/argument
 ```
 
+## Configuration
+
+You can tweak the following settings in your `config/environment.js` under the `emberDecoratorsArgument` namespace:
+
+### `typeRequired`
+
+**Type**: `Boolean` | **Default**: `false`
+
+If enabled, requires you to also specify a [`@type`](#type) for every [`@argument`](#argument).
+
+### `ignoreComponentsWithoutValidations`
+
+**Type**: `Boolean` | **Default**: `false`
+
+If enabled, components that don't have any validations defined on them will not get validated. This is very handy, if you're adding this addon to a pre-existing codebase, since it allows you to progressively migrate your components one by one.
+
 ## Running
 
 * `ember serve`

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ ember install @ember-decorators/argument
 
 ## Configuration
 
-You can tweak the following settings in your `config/environment.js` under the `emberDecoratorsArgument` namespace:
+You can tweak the following settings in your `config/environment.js` under the `@ember-decorators/argument` namespace:
 
 ### `typeRequired`
 

--- a/addon/-debug/validated-component.js
+++ b/addon/-debug/validated-component.js
@@ -34,7 +34,7 @@ if (GTE_EMBER_1_13) {
       const prototype = HAS_MODERN_FACTORY_INJECTIONS ? this.prototype : this.__super__;
       const validations = getValidationsFor(prototype) || {};
       if (
-        getWithDefault(config, 'emberDecoratorsArgument.ignoreComponentsWithoutValidations', false) &&
+        getWithDefault(config, '@ember-decorators/argument.ignoreComponentsWithoutValidations', false) &&
         Object.keys(validations).length === 0
       ) {
         return instance;

--- a/addon/-debug/validated-component.js
+++ b/addon/-debug/validated-component.js
@@ -1,5 +1,7 @@
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
+import { getWithDefault } from '@ember/object';
+import config from 'ember-get-config';
 
 import './utils/validation-decorator';
 
@@ -31,6 +33,13 @@ if (GTE_EMBER_1_13) {
 
       const prototype = HAS_MODERN_FACTORY_INJECTIONS ? this.prototype : this.__super__;
       const validations = getValidationsFor(prototype) || {};
+      if (
+        getWithDefault(config, 'emberDecoratorsArgument.ignoreComponentsWithoutValidations', false) &&
+        Object.keys(validations).length === 0
+      ) {
+        return instance;
+      }
+
       const attributes = (instance.attributeBindings || []);
       const classNames = (instance.classNameBindings || []).map((binding) => binding.split(':')[0]);
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -12,7 +12,7 @@ import { validationDecorator } from '@ember-decorators/argument/-debug';
 let internalArgumentDecorator = function(target, key, desc, options, validations) {
   if (DEBUG) {
     validations.isArgument = true;
-    validations.typeRequired = getWithDefault(config, 'emberArgumentDecorators.typeRequired', false);
+    validations.typeRequired = getWithDefault(config, 'emberDecoratorsArgument.typeRequired', false);
   }
 
   // always ensure the property is writeable, doesn't make sense otherwise (babel bug?)

--- a/addon/index.js
+++ b/addon/index.js
@@ -12,7 +12,7 @@ import { validationDecorator } from '@ember-decorators/argument/-debug';
 let internalArgumentDecorator = function(target, key, desc, options, validations) {
   if (DEBUG) {
     validations.isArgument = true;
-    validations.typeRequired = getWithDefault(config, 'emberDecoratorsArgument.typeRequired', false);
+    validations.typeRequired = getWithDefault(config, '@ember-decorators/argument.typeRequired', false);
   }
 
   // always ensure the property is writeable, doesn't make sense otherwise (babel bug?)

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = {
 
     let parentOptions = this._getParentOptions();
 
-    this.addonOptions = parentOptions.emberArgumentDecorators || {};
+    this.addonOptions = parentOptions.emberDecoratorsArgument || {};
 
     this._setupBabelOptions();
 

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = {
 
     let parentOptions = this._getParentOptions();
 
-    this.addonOptions = parentOptions.emberDecoratorsArgument || {};
+    this.addonOptions = parentOptions['@ember-decorators/argument'] || {};
 
     this._setupBabelOptions();
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,14 +1,1 @@
-{
-  "compilerOptions": {
-      "target": "ES6",
-      "experimentalDecorators": true
-  },
-  "include": [
-      "addon/**/*",
-      "tests/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
-}
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"include":["addon/**/*","tests/**/*"],"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -6,7 +6,7 @@ import { start } from 'ember-cli-qunit';
 
 import config from 'ember-get-config';
 
-config.emberArgumentDecorators = {
+config.emberDecoratorsArgument = {
   typeRequired: false
 };
 

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -6,7 +6,7 @@ import { start } from 'ember-cli-qunit';
 
 import config from 'ember-get-config';
 
-config.emberDecoratorsArgument = {
+config['@ember-decorators/argument'] = {
   typeRequired: false,
   ignoreComponentsWithoutValidations: false
 };

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -7,7 +7,8 @@ import { start } from 'ember-cli-qunit';
 import config from 'ember-get-config';
 
 config.emberDecoratorsArgument = {
-  typeRequired: false
+  typeRequired: false,
+  ignoreComponentsWithoutValidations: false
 };
 
 setResolver(resolver);

--- a/tests/unit/-debug/component/validated-component-test.js
+++ b/tests/unit/-debug/component/validated-component-test.js
@@ -5,6 +5,8 @@ import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent } from 'ember-qunit';
 import { test } from 'qunit';
 
+import config from 'ember-get-config';
+
 import { GTE_EMBER_1_13 } from 'ember-compatibility-helpers';
 
 import { argument } from '@ember-decorators/argument';
@@ -107,5 +109,34 @@ if (GTE_EMBER_1_13) {
         tagName="button"
       }}
     `);
+  });
+
+  test('does not assert on undefined args when there are no validations and `ignoreComponentsWithoutValidations` is enabled', function(assert) {
+    assert.expect(0);
+    config.emberDecoratorsArgument.ignoreComponentsWithoutValidations = true;
+
+    class FooComponent extends Component {}
+
+    this.register('component:foo-component', FooComponent);
+
+    this.render(hbs`{{foo-component foo=123}}`);
+
+    config.emberDecoratorsArgument.ignoreComponentsWithoutValidations = false;
+  });
+
+  test('asserts on args when there are validations and `ignoreComponentsWithoutValidations` is enabled', function(assert) {
+    config.emberDecoratorsArgument.ignoreComponentsWithoutValidations = true;
+
+    class FooComponent extends Component {
+      @argument foo;
+    }
+
+    this.register('component:foo-component', FooComponent);
+
+    assert.throws(() => {
+      this.render(hbs`{{foo-component bar=123}}`);
+    });
+
+    config.emberDecoratorsArgument.ignoreComponentsWithoutValidations = false;
   });
 }

--- a/tests/unit/-debug/component/validated-component-test.js
+++ b/tests/unit/-debug/component/validated-component-test.js
@@ -113,7 +113,7 @@ if (GTE_EMBER_1_13) {
 
   test('does not assert on undefined args when there are no validations and `ignoreComponentsWithoutValidations` is enabled', function(assert) {
     assert.expect(0);
-    config.emberDecoratorsArgument.ignoreComponentsWithoutValidations = true;
+    config['@ember-decorators/argument'].ignoreComponentsWithoutValidations = true;
 
     class FooComponent extends Component {}
 
@@ -121,11 +121,11 @@ if (GTE_EMBER_1_13) {
 
     this.render(hbs`{{foo-component foo=123}}`);
 
-    config.emberDecoratorsArgument.ignoreComponentsWithoutValidations = false;
+    config['@ember-decorators/argument'].ignoreComponentsWithoutValidations = false;
   });
 
   test('asserts on args when there are validations and `ignoreComponentsWithoutValidations` is enabled', function(assert) {
-    config.emberDecoratorsArgument.ignoreComponentsWithoutValidations = true;
+    config['@ember-decorators/argument'].ignoreComponentsWithoutValidations = true;
 
     class FooComponent extends Component {
       @argument foo;
@@ -137,6 +137,6 @@ if (GTE_EMBER_1_13) {
       this.render(hbs`{{foo-component bar=123}}`);
     });
 
-    config.emberDecoratorsArgument.ignoreComponentsWithoutValidations = false;
+    config['@ember-decorators/argument'].ignoreComponentsWithoutValidations = false;
   });
 }

--- a/tests/unit/-debug/type-test.js
+++ b/tests/unit/-debug/type-test.js
@@ -187,7 +187,7 @@ test('it requires primitive types or classes', function(assert) {
 });
 
 test('it throws if types are required on an argument', function(assert) {
-  config.emberDecoratorsArgument.typeRequired = true;
+  config['@ember-decorators/argument'].typeRequired = true;
 
   assert.throws(() => {
     // no default
@@ -199,7 +199,7 @@ test('it throws if types are required on an argument', function(assert) {
     Foo.create();
   }, /bar requires a type, add one using the @type decorator/);
 
-  config.emberDecoratorsArgument.typeRequired = false;
+  config['@ember-decorators/argument'].typeRequired = false;
 });
 
 test('subclass can provide value', function(assert) {

--- a/tests/unit/-debug/type-test.js
+++ b/tests/unit/-debug/type-test.js
@@ -187,7 +187,7 @@ test('it requires primitive types or classes', function(assert) {
 });
 
 test('it throws if types are required on an argument', function(assert) {
-  config.emberArgumentDecorators.typeRequired = true;
+  config.emberDecoratorsArgument.typeRequired = true;
 
   assert.throws(() => {
     // no default
@@ -199,7 +199,7 @@ test('it throws if types are required on an argument', function(assert) {
     Foo.create();
   }, /bar requires a type, add one using the @type decorator/);
 
-  config.emberArgumentDecorators.typeRequired = false;
+  config.emberDecoratorsArgument.typeRequired = false;
 });
 
 test('subclass can provide value', function(assert) {


### PR DESCRIPTION
Closes #27.

Adds the config setting `ignoreComponentsWithoutValidations`.

If this option is enabled, components without any validations will be ignored, meaning that you can assign any arguments on them.

Also renames the config namespace to `emberDecoratorsArgument` and adds a section about configuration to the README.