### PR TITLE
fix(transform): also remove `optional` type helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ module.exports = {
                 ],
                 '@ember-decorators/argument/type': [
                   'type',
+                  'optional',
                   'arrayOf',
                   'shapeOf',
                   'unionOf'


### PR DESCRIPTION
I forgot to add this for https://github.com/ember-decorators/argument/pull/37. :see_no_evil: 