### PR TITLE
bugfix(types): Leave references to shim types

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const FilterImports = require('babel-plugin-filter-imports');
+const FilterTypesImports = require('./lib/filter-types-imports-transform');
 const ValidatedComponentTransform = require('./lib/validated-component-transform');
 const VersionChecker = require('ember-cli-version-checker');
 const Funnel = require('broccoli-funnel');
@@ -106,16 +107,15 @@ module.exports = {
                 ],
                 '@ember-decorators/argument/types': [
                   'Action',
-                  'ClosureAction',
-                  'Element',
-                  'Node'
+                  'ClosureAction'
                 ],
                 '@ember-decorators/argument/validation': [
                   'immutable',
                   'required'
                 ]
-              }
-            }]
+              },
+            }],
+            FilterTypesImports
           );
         } else if (!this.addonOptions.disableValidatedComponent) {
           plugins.push(ValidatedComponentTransform);

--- a/lib/filter-types-imports-transform/index.js
+++ b/lib/filter-types-imports-transform/index.js
@@ -1,0 +1,23 @@
+/* eslint-env node */
+var path = require('path');
+
+function filterTypesImports(babel) {
+  const t = babel.types;
+
+  return {
+    name: 'convert-validated-components',
+    visitor: {
+      ImportDeclaration(path) {
+        if (path.node.source.value === '@ember-decorators/argument/types') {
+          path.remove();
+        }
+      }
+    }
+  };
+}
+
+filterTypesImports.baseDir = function() {
+  return __dirname;
+};
+
+module.exports = filterTypesImports;

--- a/lib/filter-types-imports-transform/package.json
+++ b/lib/filter-types-imports-transform/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "filter-types-imports-transform",
+  "version": "0.0.0",
+  "description": "The default blueprint for ember-cli addons.",
+  "license": "MIT",
+  "author": "",
+  "repository": ""
+}


### PR DESCRIPTION
Closes #43

Creates an extra transform that just removes the imports themselves and runs after non-shim types are removed. 