### PR TITLE
bugfix(init): Ensures that initializer gets unset in production

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -19,7 +19,10 @@ let internalArgumentDecorator = function(target, key, desc, options, validations
   desc.writable = true;
   desc.configurable = true;
 
-  if (desc.initializer === null) return;
+  if (desc.initializer === null || desc.initializer === undefined) {
+    desc.initializer = undefined;
+    return;
+  }
 
   const initializers = getOrCreateInitializersFor(target);
   initializers[key] = desc.initializer;
@@ -30,12 +33,10 @@ let internalArgumentDecorator = function(target, key, desc, options, validations
 
     let value = this[key];
 
-    if (typeof initializer === 'function') {
-      const shouldInitialize = options.defaultIfUndefined ? value === undefined : this.hasOwnProperty(key) === false;
+    const shouldInitialize = options.defaultIfUndefined ? value === undefined : this.hasOwnProperty(key) === false;
 
-      if (shouldInitialize) {
-        value = initializer.call(this);
-      }
+    if (shouldInitialize) {
+      value = initializer.call(this);
     }
 
     return value;

--- a/tests/unit/argument-test.js
+++ b/tests/unit/argument-test.js
@@ -98,3 +98,16 @@ test('it works with defaultIfUndefined', function(assert) {
   assert.equal(foo.get('bar'), 1, 'argument default gets set correctly');
   assert.equal(fooWithValues.get('bar'), 3, 'argument default can be overriden');
 });
+
+test('it works if no default value was given', function(assert) {
+  class Foo extends EmberObject {
+    @argument
+    bar;
+  }
+
+  const foo = Foo.create();
+  const fooWithValues = Foo.create({ bar: 3 });
+
+  assert.equal(foo.get('bar'), undefined, 'argument default gets set correctly');
+  assert.equal(fooWithValues.get('bar'), 3, 'argument default can be overriden');
+});


### PR DESCRIPTION
With the current transforms, as soon as a property gets decorated it will either:

1. Have an initializer that returns the initial value, even if it is a simple value
2. Have no value and `initializer === null`

Either way the value will always be defined on the property which messes with our current setup. However, if the value of the initializer is `undefined`, the entire descriptor gets tossed out, making the property act as if nothing has been assigned at all which is what we want 😄

This would generally work in development because [validator decorators already do this](https://github.com/ember-decorators/argument/blob/master/addon/-debug/utils/validation-decorator.js#L111) for fields that are not arguments. Because they may have already unset the value of the initializer, we need to check if it is `null || undefined` and escape early in both cases.