### PR TITLE
Fix treeForAddon super call

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
     });
 
 
-    return this._super(filteredTree);
+    return this._super.treeForAddon.call(this, filteredTree);
   },
 
   _setupBabelOptions() {


### PR DESCRIPTION
`this._super` is not called correctly and can lead to error like this:

```
Visit http://ember-cli.com/user-guide/#watchman for more info.
this._super is not a function
TypeError: this._super is not a function
    at Class.treeForAddon (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-attacher/node_modules/ember-popper/node_modules/@ember-decorators/argument/index.js:44:17)
    at Class._treeFor (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:322:31)
    at Class.treeFor (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:290:19)
    at /home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:244:32
    at Array.map (native)
    at Class.eachAddonInvoke (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:242:22)
    at Class.treeFor (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:289:20)
    at /home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:244:32
    at Array.map (native)
    at Class.eachAddonInvoke (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/addon.js:242:22)
```