### PR TITLE
feat(required): Allow required fields to be provided by class

### DIFF
--- a/addon/-debug/utils/validation-decorator.js
+++ b/addon/-debug/utils/validation-decorator.js
@@ -55,7 +55,7 @@ EmberObject.reopenClass({
         typeRequired
       } = validations[key];
 
-      if (isRequired && !instance.hasOwnProperty(key)) {
+      if (isRequired && instance[key] === undefined && !instance.hasOwnProperty(key)) {
         throw new RequiredFieldError(`${constructor} requires a '${key}' argument to be passed in when using the component`);
       }
 

--- a/tests/unit/-debug/required-test.js
+++ b/tests/unit/-debug/required-test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
+import { computed } from 'ember-decorators/object';
 import { argument } from '@ember-decorators/argument';
 import { required } from '@ember-decorators/argument/validation';
 
@@ -51,6 +52,49 @@ test('required argument can be provided by subclass', function(assert) {
 
   class Bar extends Foo {
     prop = 1;
+  }
+
+  const bar = Bar.create();
+
+  assert.equal(bar.get('prop'), 1);
+});
+
+
+test('required argument can be provided by subclass via getter', function(assert) {
+  assert.expect(1);
+
+  class Foo extends EmberObject {
+    @required
+    @argument
+    prop;
+  }
+
+  class Bar extends Foo {
+    get prop() {
+      return 1;
+    }
+  }
+
+  const bar = Bar.create();
+
+  assert.equal(bar.get('prop'), 1);
+});
+
+
+test('required argument can be provided by subclass via computed', function(assert) {
+  assert.expect(1);
+
+  class Foo extends EmberObject {
+    @required
+    @argument
+    prop;
+  }
+
+  class Bar extends Foo {
+    @computed
+    get prop() {
+      return 1;
+    }
   }
 
   const bar = Bar.create();


### PR DESCRIPTION
Currently required fields are only accepted if they are on the instance
(hasOwnProperty). This is unflexible, as a subclass may choose to provide
an argument via a computed or getter which would be valid, but would not
meet this requirement. The additional check verifies that the field is
empty, and then we check to see if it also has not been defined on the
instance (undefined only makes sense as an instance value).