### PR TITLE
bugfix(validators): Make validators work with computeds

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,8 @@ module.exports = {
     browser: true,
     es6: true
   },
-  rules: {
+  rules: {},
+  globals: {
+    'Ember': true
   }
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "4"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:

--- a/addon/-debug/utils/validation-decorator.js
+++ b/addon/-debug/utils/validation-decorator.js
@@ -1,9 +1,9 @@
 import EmberObject from '@ember/object';
-import { computed, get } from '@ember/object';
+import { computed } from '@ember/object';
 
 import { getValidationsFor, getValidationsForKey } from './validations-for';
 
-import { SUPPORTS_NEW_COMPUTED } from 'ember-compatibility-helpers';
+import { SUPPORTS_NEW_COMPUTED, IS_EMBER_2 } from 'ember-compatibility-helpers';
 
 import {
   MutabilityError,
@@ -27,12 +27,134 @@ function makeComputed(desc) {
   }
 }
 
-function runValidators(validators, constructor, key, value) {
+function getPropertyDescriptor(object, key) {
+  if (object === undefined) return;
+
+  return Object.getOwnPropertyDescriptor(object, key) || getPropertyDescriptor(Object.getPrototypeOf(object), key);
+}
+
+function runValidators(validators, constructor, key, value, phase) {
   validators.forEach((validator) => {
     if (validator(value) === false) {
-      throw new TypeError(`${constructor}#${key} expected value of type ${validator}, but received: ${value}`);
+      throw new TypeError(`${constructor}#${key} expected value of type ${validator} during '${phase}', but received: ${value}`);
     }
   });
+}
+
+function isMandatorySetter(setter) {
+  return setter && setter.toString().match('You must use .*set()') !== null;
+}
+
+function wrapField(constructor, instance, validations, key) {
+  const {
+    isImmutable,
+    isRequired,
+    typeValidators,
+    typeRequired
+  } = validations[key];
+
+  if (isRequired && instance[key] === undefined && !instance.hasOwnProperty(key)) {
+    throw new RequiredFieldError(`${constructor} requires a '${key}' argument to be passed in when using the component`);
+  }
+
+  let {
+    get: originalGet,
+    set: originalSet,
+    value: cachedValue
+  } = getPropertyDescriptor(instance, key);
+
+  let isComputed = false;
+  let meta = Ember.meta(instance);
+
+  if (meta.peekDescriptors) {
+    let computedDescriptor = meta.peekDescriptors(key);
+    isComputed = !!computedDescriptor;
+
+    cachedValue = isComputed ? computedDescriptor : cachedValue;
+  } else {
+    isComputed = cachedValue !== null && typeof cachedValue === 'object' && cachedValue.isDescriptor;
+  }
+
+  let getter, setter;
+
+  if (isComputed) {
+    getter = cachedValue.get.bind(cachedValue, instance, key);
+    setter = cachedValue.set.bind(cachedValue, instance, key);
+  } else if ((typeof originalGet === 'function' || typeof originalSet === 'function') && !isMandatorySetter(originalSet)) {
+    getter = originalGet ? originalGet.bind(instance) : () => { throw new Error('attempted to get a property without a getter') };
+    setter = originalSet ? originalSet.bind(instance) : () => { throw new Error('attempted to set a property without a setter') };
+  } else {
+    // Reset the cached value to get the true initial value of the field
+    cachedValue = instance[key];
+
+    getter = () => cachedValue;
+    setter = (value) => cachedValue = value;
+  }
+
+  let originalValue = getter();
+
+  if (typeValidators.length > 0) {
+    runValidators(typeValidators, constructor, key, originalValue, 'init');
+  } else if (typeRequired) {
+    throw new TypeError(`${constructor}#${key} requires a type, add one using the @type decorator`);
+  }
+
+  if (isImmutable) {
+    let wrapperComputed = makeComputed({
+      get() {
+        let newValue = getter();
+
+        if (newValue !== originalValue) {
+          throw new MutabilityError(`Immutable value ${constructor}#${key} changed by underlying computed, original value: ${originalValue}, new value: ${newValue}`);
+        }
+
+        return newValue;
+      },
+
+      set(key, value) {
+        throw new MutabilityError(`Attempted to set ${constructor}#${key} to the value ${value} but the field is immutable`);
+      }
+    });
+
+    if (!isComputed) {
+      wrapperComputed.volatile();
+    }
+
+    Ember.defineProperty(instance, key, { value: wrapperComputed });
+  } else if (typeValidators.length > 0) {
+    let wrapperComputed = makeComputed({
+      get() {
+        let newValue = getter();
+
+        runValidators(typeValidators, constructor, key, newValue, 'get');
+
+        return newValue;
+      },
+
+      set(key, value) {
+        runValidators(typeValidators, constructor, key, value, 'set');
+
+        // Legacy Ember does not return the value from ComputedProperty.set calls,
+        // so we have to side-effect and return the value directly
+        setter(value);
+
+        // Volatile computeds cannot be watched (they never trigger `propertyDidChange`)
+        // in Ember 2 so we need to trigger it manually in the case where we're proxying
+        // to a simple value/getter/setter
+        if (!isComputed && IS_EMBER_2) {
+          Ember.propertyDidChange(instance, key);
+        }
+
+        return value;
+      }
+    });
+
+    if (!isComputed) {
+      wrapperComputed.volatile();
+    }
+
+    Ember.defineProperty(instance, key, { value: wrapperComputed });
+  }
 }
 
 EmberObject.reopenClass({
@@ -48,50 +170,7 @@ EmberObject.reopenClass({
     }
 
     for (let key in validations) {
-      const {
-        isImmutable,
-        isRequired,
-        typeValidators,
-        typeRequired
-      } = validations[key];
-
-      if (isRequired && instance[key] === undefined && !instance.hasOwnProperty(key)) {
-        throw new RequiredFieldError(`${constructor} requires a '${key}' argument to be passed in when using the component`);
-      }
-
-      let value = get(instance, key);
-
-      if (typeValidators.length > 0) {
-        runValidators(typeValidators, constructor, key, value);
-      } else if (typeRequired) {
-        throw new TypeError(`${constructor}#${key} requires a type, add one using the @type decorator`);
-      }
-
-      if (isImmutable) {
-        instance[key] = makeComputed({
-          get() {
-            return value;
-          },
-
-          set(key, value) {
-            throw new MutabilityError(`Attempted to set ${constructor}#${key} to the value ${value} but the field is immutable`);
-          }
-        });
-      } else if (typeValidators.length) {
-        let cachedValue = value;
-
-        instance[key] = makeComputed({
-          get() {
-            return cachedValue;
-          },
-
-          set(key, value) {
-            runValidators(typeValidators, constructor, key, value);
-
-            return cachedValue = value;
-          }
-        });
-      }
+      wrapField(constructor, instance, validations, key);
     }
 
     return instance;

--- a/tests/unit/-debug/immutable-test.js
+++ b/tests/unit/-debug/immutable-test.js
@@ -1,6 +1,7 @@
 import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
+import { computed } from 'ember-decorators/object';
 import { argument } from '@ember-decorators/argument';
 import { type } from '@ember-decorators/argument/type';
 import { immutable } from '@ember-decorators/argument/validation';
@@ -80,4 +81,50 @@ test('subclass can make field immutable', function(assert) {
   assert.throws(() => {
     bar.set('bar', '123');
   }, /Attempted to set .*#bar to the value 123 but the field is immutable/);
+});
+
+test('immutable value can be provided by computed', function(assert) {
+
+  class Foo extends EmberObject {
+    @immutable
+    prop;
+  }
+
+  class Bar extends Foo {
+    value = 123;
+
+    @computed('value')
+    get prop() {
+      return this.value;
+    }
+  }
+
+  const bar = Bar.create();
+
+  assert.equal(bar.get('prop'), 123, 'default value provided');
+});
+
+test('immutable value cannot be changed by computed', function(assert) {
+
+  class Foo extends EmberObject {
+    @immutable
+    prop;
+  }
+
+  class Bar extends Foo {
+    value = 123;
+
+    @computed('value')
+    get prop() {
+      return this.value;
+    }
+  }
+
+  const bar = Bar.create();
+
+  bar.set('value', 456);
+
+  assert.throws(() => {
+    bar.get('prop');
+  }, /Immutable value Ember.Object#prop changed by underlying computed, original value: 123, new value: 456/);
 });

--- a/tests/unit/-debug/type-test.js
+++ b/tests/unit/-debug/type-test.js
@@ -1,6 +1,8 @@
 import EmberObject from '@ember/object';
+import { addObserver } from '@ember/object/observers';
 import { test, module } from 'qunit';
 
+import { computed } from 'ember-decorators/object';
 import { argument } from '@ember-decorators/argument';
 import { type } from '@ember-decorators/argument/type';
 
@@ -55,7 +57,7 @@ test('it throws if an incorrect value is provided', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /bar expected value of type string, but received: 2/);
+  }, /bar expected value of type string during 'init', but received: 2/);
 });
 
 test('it works with the class hierarchy', function(assert) {
@@ -77,11 +79,11 @@ test('it works with the class hierarchy', function(assert) {
 
   assert.throws(() => {
     Quix.create({ prop: 2 });
-  }, /prop expected value of type string, but received: 2/);
+  }, /prop expected value of type string during 'init', but received: 2/);
 
   assert.throws(() => {
     Quix.create({ anotherProp: 'val' });
-  }, /anotherProp expected value of type number, but received: val/);
+  }, /anotherProp expected value of type number during 'init', but received: val/);
 });
 
 test('it throws if an incorrect default default value is provided', function(assert) {
@@ -94,7 +96,7 @@ test('it throws if an incorrect default default value is provided', function(ass
     }
 
     Foo.create();
-  }, /bar expected value of type string, but received: undefined/);
+  }, /bar expected value of type string during 'init', but received: undefined/);
 
   assert.throws(() => {
     // incorrect default
@@ -105,7 +107,7 @@ test('it throws if an incorrect default default value is provided', function(ass
     }
 
     Foo.create();
-  }, /bar expected value of type string, but received: 2/);
+  }, /bar expected value of type string during 'init', but received: 2/);
 });
 
 test('throws if the property is set to an incorrect type', function(assert) {
@@ -119,7 +121,7 @@ test('throws if the property is set to an incorrect type', function(assert) {
 
     let foo = Foo.create();
     foo.set('bar', 2);
-  }, /bar expected value of type string, but received: 2/);
+  }, /bar expected value of type string during 'set', but received: 2/);
 });
 
 test('it requires exactly one type argument', function(assert) {
@@ -218,7 +220,7 @@ test('subclass can provide value', function(assert) {
 
   assert.throws(() => {
     Foo.create();
-  }, /prop expected value of type string, but received: undefined/);
+  }, /prop expected value of type string during 'init', but received: undefined/);
 });
 
 test('subtypes can be added to classes', function(assert) {
@@ -239,7 +241,7 @@ test('subtypes can be added to classes', function(assert) {
 
   assert.throws(() => {
     Bar.create({ prop: 123 });
-  }, /prop expected value of type string, but received: 123/);
+  }, /prop expected value of type string during 'init', but received: 123/);
 });
 
 test('subtypes cannot deviate from superclass type', function(assert) {
@@ -258,5 +260,142 @@ test('subtypes cannot deviate from superclass type', function(assert) {
 
   assert.throws(() => {
     Bar.create({ prop: '123' });
-  }, /prop expected value of type number, but received: 123/);
+  }, /prop expected value of type number during 'init', but received: 123/);
+});
+
+test('typed value can be provided by computed', function(assert) {
+  class Foo extends EmberObject {
+    @type('number')
+    prop;
+  }
+
+  class Bar extends Foo {
+    value = 123;
+
+    @computed('value')
+    get prop() {
+      return this.value;
+    }
+
+    set prop(value) {
+      this.set('value', value);
+    }
+  }
+
+  const bar = Bar.create();
+
+  // Works by default
+  assert.equal(bar.get('prop'), 123, 'default value provided');
+
+  // Works when dependent key is set
+  bar.set('value', 456)
+  assert.equal(bar.get('prop'), 456, 'can set dependent key');
+
+  // Works when set directly
+  bar.set('prop', 789);
+  assert.equal(bar.get('value'), 789, 'setter works correctly')
+  assert.equal(bar.get('prop'), 789, 'correct value set');
+
+  // Throws when computed returns incorrect value
+  assert.throws(() => {
+    bar.set('value', 'foo');
+    bar.get('prop');
+  }, /prop expected value of type number during 'get', but received: foo/);
+
+  // Throws when set to incorrect value
+  assert.throws(() => {
+    bar.set('prop', 'foo');
+  }, /prop expected value of type number during 'set', but received: foo/);
+});
+
+test('typed value can be provided by native getter/setter', function(assert) {
+  class Foo extends EmberObject {
+    @type('number')
+    prop;
+  }
+
+  class Bar extends Foo {
+    value = 123;
+
+    get prop() {
+      return this.value;
+    }
+
+    set prop(value) {
+      this.value = value;
+    }
+  }
+
+  const bar = Bar.create();
+
+  // Works by default
+  assert.equal(bar.get('prop'), 123, 'default value provided');
+
+  // Works when dependent key is set
+  bar.value = 456;
+  assert.equal(bar.get('prop'), 456, 'can set dependent key');
+
+  // Works when set directly
+  bar.set('prop', 789);
+  assert.equal(bar.value, 789, 'setter works correctly')
+  assert.equal(bar.get('prop'), 789, 'correct value set');
+
+  // Throws when computed returns incorrect value
+  assert.throws(() => {
+    bar.value = 'foo';
+    bar.get('prop');
+  }, /prop expected value of type number during 'get', but received: foo/);
+
+  // Throws when set to incorrect value
+  assert.throws(() => {
+    bar.set('prop', 'foo');
+  }, /prop expected value of type number during 'set', but received: foo/);
+});
+
+test('typed value can be watched', function(assert) {
+  class Foo extends EmberObject {
+    @type('number')
+    prop = 123;
+
+    @computed('prop')
+    get watcher() {
+      return this.get('prop');
+    }
+  }
+
+  const foo = Foo.create();
+
+  // Works by default
+  assert.equal(foo.get('watcher'), 123, 'default value provided');
+
+  // Works when dependent key is set
+  foo.set('prop', 456)
+  assert.equal(foo.get('prop'), 456, 'can set dependent key');
+  assert.equal(foo.get('watcher'), 456, 'computed value is updated');
+});
+
+test('typed value does not trigger mandatory setter', function(assert) {
+  assert.expect(3);
+
+  class Foo extends EmberObject {
+    constructor() {
+      super();
+
+      addObserver(this, 'prop', () => {
+        assert.ok(true, 'observer called');
+      });
+    }
+
+    @type('number')
+    prop = 123;
+  }
+
+  const foo = Foo.create();
+
+  // Works by default
+  assert.equal(foo.get('prop'), 123, 'default value provided');
+
+  // Works when dependent key is set
+  foo.set('prop', 456)
+  assert.equal(foo.get('prop'), 456, 'can set dependent key');
 });

--- a/tests/unit/-debug/types/array-of-test.js
+++ b/tests/unit/-debug/types/array-of-test.js
@@ -27,7 +27,7 @@ test('it throws if array items do not match', function(assert) {
     }
 
     Foo.create({ bar: ['baz', 2] });
-  }, /bar expected value of type arrayOf\(string\), but received: baz,2/);
+  }, /bar expected value of type arrayOf\(string\) during 'init', but received: baz,2/);
 });
 
 test('it throws if type does not match', function(assert) {
@@ -39,7 +39,7 @@ test('it throws if type does not match', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /bar expected value of type arrayOf\(string\), but received: 2/);
+  }, /bar expected value of type arrayOf\(string\) during 'init', but received: 2/);
 });
 
 test('it throws if incorrect number of items passed in', function(assert) {

--- a/tests/unit/-debug/types/optional-test.js
+++ b/tests/unit/-debug/types/optional-test.js
@@ -30,11 +30,11 @@ test('it throws if type does not match', function(assert) {
 
   assert.throws(() => {
     Foo.create({ bar: 2 });
-  }, /bar expected value of type optional\(string\), but received: 2/);
+  }, /bar expected value of type optional\(string\) during 'init', but received: 2/);
 
   assert.throws(() => {
     Foo.create({ bar: new Date() });
-  }, /bar expected value of type optional\(string\), but received/);
+  }, /bar expected value of type optional\(string\) during 'init', but received/);
 });
 
 test('it requires primitive types or classes', function(assert) {

--- a/tests/unit/-debug/types/shape-of-test.js
+++ b/tests/unit/-debug/types/shape-of-test.js
@@ -27,7 +27,7 @@ test('it throws if array items do not match', function(assert) {
     }
 
     Foo.create({ bar: { qux: 'baz' } });
-  }, /bar expected value of type shapeOf\({foo:string}\), but received: \[object Object\]/);
+  }, /bar expected value of type shapeOf\({foo:string}\) during 'init', but received: \[object Object\]/);
 });
 
 test('it throws if type does not match', function(assert) {
@@ -39,7 +39,7 @@ test('it throws if type does not match', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /bar expected value of type shapeOf\({foo:string}\), but received: 2/);
+  }, /bar expected value of type shapeOf\({foo:string}\) during 'init', but received: 2/);
 });
 
 test('it throws if non-object passed in', function(assert) {

--- a/tests/unit/-debug/types/union-of-test.js
+++ b/tests/unit/-debug/types/union-of-test.js
@@ -29,11 +29,11 @@ test('it throws if type does not match', function(assert) {
 
   assert.throws(() => {
     Foo.create({ bar: null });
-  }, /bar expected value of type unionOf\(string,undefined\), but received: null/);
+  }, /bar expected value of type unionOf\(string,undefined\) during 'init', but received: null/);
 
   assert.throws(() => {
     Foo.create({ bar: new Date() });
-  }, /bar expected value of type unionOf\(string,undefined\), but received/);
+  }, /bar expected value of type unionOf\(string,undefined\) during 'init', but received/);
 });
 
 test('it requires primitive types or classes', function(assert) {


### PR DESCRIPTION
Currently validators do not work with computeds. The underlying value will
be gotten the first time and cached forever, throwing away any computed
value. This change makes validators check to see if the cached value is a
computed property, and if so proxy directly to it. In the future we can
check to see if the value has an ES getter as well.