### PR TITLE
refactor(validated-property): Adds ValidatedProperty class

### DIFF
--- a/addon/-debug/utils/computed.js
+++ b/addon/-debug/utils/computed.js
@@ -1,23 +1,3 @@
-import { computed } from '@ember/object';
-
-import { SUPPORTS_NEW_COMPUTED } from 'ember-compatibility-helpers';
-
-export function makeComputed(desc) {
-  if (SUPPORTS_NEW_COMPUTED) {
-    return computed(desc);
-  } else {
-    const { get, set } = desc;
-
-    return computed(function (key, value) {
-      if (arguments.length > 1) {
-        return set.call(this, key, value);
-      }
-
-      return get.call(this);
-    });
-  }
-}
-
 export function isMandatorySetter(setter) {
   return setter && setter.toString().match('You must use .*set()') !== null;
 }


### PR DESCRIPTION
Currently, we rely on ComputedProperties to wrap existing descriptors and
proxy to them after doing their type checking. CPs were not really meant
for this, and their behavior is pretty bugprone as such. This refactor
replaces the CPs with a simple class that is API compatible with CPs -
that is, Ember will detect them as CPs and call their set/get methods
and other hooks as appropriate.

This neatly sidesteps a lot of the issues we've been having, and cleans up
a huge amount of the branching logic in wrapping properties. However, it
means we're relying on fairly large swathes of private API and hoping it
doesn't break. The future strategy here relies on ES5 getters - when those
are implemented, we will be able to replace native getter with our own which
does type checking, and we will be able to replace the setter via the meta
API, which is definitely intimate API.