### PR TITLE
bugfix(validations): Fixes validations in legacy

### DIFF
--- a/addon/-debug/utils/validation-decorator.js
+++ b/addon/-debug/utils/validation-decorator.js
@@ -1,5 +1,10 @@
 import Ember from 'ember';
 import EmberObject from '@ember/object';
+import Mixin from '@ember/object/mixin';
+
+import Component from '@ember/component';
+import Controller from '@ember/controller';
+import Service from '@ember/service';
 
 import {
   isMandatorySetter,
@@ -236,7 +241,7 @@ function wrapField(klass, instance, validations, keyName) {
   });
 }
 
-const validatingCreateMixin = {
+const ValidatingCreateMixin = Mixin.create({
   create() {
     const instance = this._super.apply(this, arguments);
 
@@ -254,9 +259,19 @@ const validatingCreateMixin = {
 
     return instance;
   }
-};
+});
 
-EmberObject.reopenClass(validatingCreateMixin);
+EmberObject.reopenClass(ValidatingCreateMixin);
+
+// Reopening a parent class does not apply the mixin to existing child classes,
+// so we need to apply it directly
+ValidatingCreateMixin.apply(Component);
+ValidatingCreateMixin.apply(Service);
+ValidatingCreateMixin.apply(Controller);
+
+if (window.DS !== undefined && window.DS.Model !== undefined) {
+  ValidatingCreateMixin.apply(window.DS.Model);
+}
 
 export default function validationDecorator(fn) {
   return function(target, key, desc, options) {

--- a/addon/utils/make-computed.js
+++ b/addon/utils/make-computed.js
@@ -1,0 +1,19 @@
+import { computed } from '@ember/object';
+
+import { SUPPORTS_NEW_COMPUTED } from 'ember-compatibility-helpers';
+
+export default function makeComputed(desc) {
+  if (SUPPORTS_NEW_COMPUTED) {
+    return computed(desc);
+  } else {
+    const { get, set } = desc;
+
+    return computed(function (key, value) {
+      if (arguments.length > 1) {
+        return set.call(this, key, value);
+      }
+
+      return get.call(this);
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-decorators": "^1.3.1",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
-    "ember-legacy-class-transform": "^0.1.0",
+    "ember-legacy-class-shim": "^1.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-native-dom-helpers": "^0.5.4",
     "ember-resolver": "^4.0.0",

--- a/tests/unit/-debug/component/validated-component-test.js
+++ b/tests/unit/-debug/component/validated-component-test.js
@@ -10,24 +10,37 @@ import config from 'ember-get-config';
 import { GTE_EMBER_1_13 } from 'ember-compatibility-helpers';
 
 import { argument } from '@ember-decorators/argument';
+import { type } from '@ember-decorators/argument/type';
 import { attribute, className } from 'ember-decorators/component';
 
+let originalTestAdapterException;
+
+moduleForComponent('validate component', {
+  integration: true,
+  beforeEach() {
+      originalTestAdapterException = Ember.Test.adapter.exception;
+      Ember.Test.adapter.exception = function(e) {
+        throw e;
+      };
+  },
+  afterEach() {
+      Ember.Test.adapter.exception = originalTestAdapterException;
+  }
+});
+
+test('asserts on args which are not the correct type', function(assert) {
+  class FooComponent extends Component {
+    @argument @type('string') foo;
+  }
+
+  this.register('component:foo-component', FooComponent);
+
+  assert.throws(() => {
+    this.render(hbs`{{foo-component foo=123}}`);
+  }, /#foo expected value of type string during 'init', but received: 123/);
+});
+
 if (GTE_EMBER_1_13) {
-  let originalTestAdapterException;
-
-  moduleForComponent('validate component', {
-      integration: true,
-      beforeEach() {
-          originalTestAdapterException = Ember.Test.adapter.exception;
-          Ember.Test.adapter.exception = function(e) {
-            throw e;
-          };
-      },
-      afterEach() {
-          Ember.Test.adapter.exception = originalTestAdapterException;
-      }
-   });
-
   test('asserts on args which are not defined', function(assert) {
     class FooComponent extends Component {}
 

--- a/tests/unit/argument-test.js
+++ b/tests/unit/argument-test.js
@@ -115,9 +115,10 @@ test('it works with defaultIfNullish', function(assert) {
   assert.equal(fooWithNull.get('bar'), 1, 'argument default gets set correctly');
   assert.equal(fooWithValues.get('bar'), 3, 'argument default can be overriden');
 
-  fooWithUndefined.set('bar', undefined);
+  fooWithUndefined.set('bar', null);
   fooWithNull.set('bar', undefined);
-  assert.equal(fooWithUndefined.get('bar'), 1, 'argument cannot be set to undefined in repeated usage');
+  assert.equal(fooWithUndefined.get('bar'), 1, 'argument cannot be set to null in repeated usage');
+  assert.equal(fooWithNull.get('bar'), 1, 'argument cannot be set to undefined in repeated usage');
 });
 
 test('it works if no default value was given', function(assert) {

--- a/tests/unit/component/component-test.js
+++ b/tests/unit/component/component-test.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { addObserver } from '@ember/object/observers';
 
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent } from 'ember-qunit';
@@ -56,4 +57,93 @@ test('argument value can be overridden in subclass', function(assert) {
   this.render(hbs`{{foo-component id="bar"}}`);
 
   assert.equal(find('#bar').textContent, '123');
+});
+
+test('argument works with bindings', function(assert) {
+  assert.expect(1);
+
+  let calls = [];
+
+  class FooComponent extends Component {
+    @argument foo = true;
+
+    didInsertElement() {
+      addObserver(this, 'foo', () => {
+        calls.push(this.get('foo'));
+      });
+    }
+  }
+
+  this.register('component:foo-component', FooComponent);
+
+  this.render(hbs`{{foo-component foo=bar}}`);
+
+  this.set('bar', false);
+  this.set('bar', true);
+  this.set('bar', false);
+  this.set('bar', false);
+  this.set('bar', true);
+  this.set('bar', 123);
+  this.set('bar', 123);
+
+  assert.deepEqual(calls, [false, true, false, true, 123], 'binding updated correctly');
+});
+
+test('argument defaultIfUndefined works with bindings', function(assert) {
+  assert.expect(1);
+
+  let vals = [];
+
+  class FooComponent extends Component {
+    @argument({ defaultIfUndefined: true })
+    foo = true;
+
+    didInsertElement() {
+      vals.push(this.get('foo'));
+
+      addObserver(this, 'foo', () => vals.push(this.get('foo')));
+    }
+  }
+
+  this.set('foo', undefined);
+
+  this.register('component:foo-component', FooComponent);
+
+  this.render(hbs`{{foo-component foo=foo}}`);
+
+  this.set('foo', 123);
+  this.set('foo', undefined);
+
+  assert.deepEqual(vals, [true, 123, true]);
+});
+
+test('argument defaultIfNullish works with bindings', function(assert) {
+  assert.expect(1);
+
+  let vals = [];
+
+  class FooComponent extends Component {
+    @argument({ defaultIfNullish: true })
+    foo = true;
+
+    @argument({ defaultIfNullish: true })
+    bar = true;
+
+    didInsertElement() {
+      vals.push(this.get('foo'));
+
+      addObserver(this, 'foo', () => vals.push(this.get('foo')));
+    }
+  }
+
+  this.set('foo', undefined);
+
+  this.register('component:foo-component', FooComponent);
+
+  this.render(hbs`{{foo-component foo=foo}}`);
+
+  this.set('foo', 123);
+  this.set('foo', null);
+
+  assert.deepEqual(vals, [true, 123, true]);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,10 +651,6 @@ babel-plugin-debug-macros@^0.1.10, babel-plugin-debug-macros@^0.1.11:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-ember-legacy-class-constructor@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-legacy-class-constructor/-/babel-plugin-ember-legacy-class-constructor-0.1.4.tgz#dfe715b9bdb66f6c7e9eccc620137c03b3fa89e0"
-
 babel-plugin-ember-modules-api-polyfill@^2.0.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.2.1.tgz#e63f90cc3c71cc6b3b69fb51b4f60312d6cf734c"
@@ -2453,12 +2449,10 @@ ember-get-config@^0.2.3:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^6.3.0"
 
-ember-legacy-class-transform@^0.1.0:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/ember-legacy-class-transform/-/ember-legacy-class-transform-0.1.4.tgz#0dd588b8561a4d31c080d5d7ada64521365b3806"
+ember-legacy-class-shim@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-legacy-class-shim/-/ember-legacy-class-shim-1.0.0.tgz#569afce1419d3075e41b324fbf8195f6493e3396"
   dependencies:
-    babel-plugin-ember-legacy-class-constructor "^0.1.4"
-    ember-cli-babel "^6.3.0"
     ember-cli-version-checker "^2.0.0"
 
 ember-load-initializers@^1.0.0:


### PR DESCRIPTION
Updates to using the new legacy class shim which is lighterweight and more inline with the way classes actually behave. Also includes the following fixes for behavior that broke as a result:

* Updates reopening class to actually apply the mixin to already defined classes so they are correctly updated.
* Updates `defaultIfUndefined` and `defaultIfNullish` to be computeds instead of plain ES getters/setters. The getter/setter strategy unfortunately doesn't work until later on (~Ember@2.7) so we need to do it this way for now. We'll update to a plain getter + cached setter once ES5 getters land in Ember beta/release
* Updates `defaultIfUndefined` and `defaultIfNullish` to re-initialize _every time_ they are set to null/undefined. This is the behavior that most people will probably want when using these options, since every time a single arg updates on a component, all args are reassigned and initialized.
* Adds tests for checking that component bindings work as expected with the decorators