### PR TITLE
[bugfix] Improves error messages

### DIFF
--- a/addon/-debug/validated-component.js
+++ b/addon/-debug/validated-component.js
@@ -48,7 +48,7 @@ if (GTE_EMBER_1_13) {
           || classNames.indexOf(key) !== -1;
 
         assert(
-          `Attempted to assign '${key}' value on a ${this} component, but no argument was defined for that key. Use the @argument helper on the class field to define an argument which can be passed into the component`,
+          `Attempted to assign the argument '${key}' on an instance of ${this.name || this}, but no argument was defined for that key. Use the @argument helper on the class field to define an argument for that class.`,
           isValidArgOrAttr
         );
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-decorators": "^1.3.1",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
-    "ember-legacy-class-shim": "^1.0.0",
+    "ember-legacy-class-shim": "^1.0.1",
     "ember-load-initializers": "^1.0.0",
     "ember-native-dom-helpers": "^0.5.4",
     "ember-resolver": "^4.0.0",

--- a/tests/unit/-debug/component/validated-component-test.js
+++ b/tests/unit/-debug/component/validated-component-test.js
@@ -37,7 +37,7 @@ test('asserts on args which are not the correct type', function(assert) {
 
   assert.throws(() => {
     this.render(hbs`{{foo-component foo=123}}`);
-  }, /#foo expected value of type string during 'init', but received: 123/);
+  }, /FooComponent#foo expected value of type string during 'init', but received: 123/);
 });
 
 if (GTE_EMBER_1_13) {
@@ -48,7 +48,7 @@ if (GTE_EMBER_1_13) {
 
     assert.throws(() => {
       this.render(hbs`{{foo-component foo=123}}`);
-    }, /Attempted to assign 'foo'/);
+    }, /Attempted to assign the argument 'foo' on an instance of FooComponent/);
   });
 
   test('does not assert on args which are defined', function(assert) {

--- a/tests/unit/-debug/immutable-test.js
+++ b/tests/unit/-debug/immutable-test.js
@@ -19,7 +19,7 @@ test('it works', function(assert) {
 
   assert.throws(() => {
     foo.set('bar', 123);
-  }, /Attempted to set .*#bar to the value 123 but the field is immutable/);
+  }, /Attempted to set Foo#bar to the value 123 but the field is immutable/);
 });
 
 test('it cannot be overridden', function(assert) {
@@ -40,7 +40,7 @@ test('it cannot be overridden', function(assert) {
 
   assert.throws(() => {
     bar.set('bar', '123');
-  }, /Attempted to set .*#bar to the value 123 but the field is immutable/);
+  }, /Attempted to set Bar#bar to the value 123 but the field is immutable/);
 });
 
 test('default value can be overriden', function(assert) {
@@ -60,7 +60,7 @@ test('default value can be overriden', function(assert) {
 
   assert.throws(() => {
     bar.set('bar', '123');
-  }, /Attempted to set .*#bar to the value 123 but the field is immutable/);
+  }, /Attempted to set Bar#bar to the value 123 but the field is immutable/);
 });
 
 test('subclass can make field immutable', function(assert) {
@@ -80,7 +80,7 @@ test('subclass can make field immutable', function(assert) {
 
   assert.throws(() => {
     bar.set('bar', '123');
-  }, /Attempted to set .*#bar to the value 123 but the field is immutable/);
+  }, /Attempted to set Bar#bar to the value 123 but the field is immutable/);
 });
 
 test('immutable value can be provided by computed', function(assert) {
@@ -126,5 +126,5 @@ test('immutable value cannot be changed by computed', function(assert) {
 
   assert.throws(() => {
     bar.get('prop');
-  }, /Immutable value Ember.Object#prop changed by underlying computed, original value: 123, new value: 456/);
+  }, /Immutable value Bar#prop changed by underlying computed, original value: 123, new value: 456/);
 });

--- a/tests/unit/-debug/required-test.js
+++ b/tests/unit/-debug/required-test.js
@@ -20,7 +20,7 @@ test('it works', function(assert) {
 
   assert.throws(() => {
     Foo.create();
-  }, /requires a 'prop' argument to be passed in when using the component/);
+  }, /Foo#prop is a required value, but was not provided/);
 });
 
 test('it works with subclasses', function(assert) {
@@ -38,7 +38,7 @@ test('it works with subclasses', function(assert) {
 
   assert.throws(() => {
     Bar.create();
-  }, /requires a 'prop' argument to be passed in when using the component/);
+  }, /Bar#prop is a required value, but was not provided/);
 });
 
 test('required argument can be provided by subclass', function(assert) {
@@ -121,5 +121,5 @@ test('subclass can make a field required', function(assert) {
 
   assert.throws(() => {
     Bar.create();
-  }, /requires a 'prop' argument to be passed in when using the component/);
+  }, /Bar#prop is a required value, but was not provided/);
 });

--- a/tests/unit/-debug/type-test.js
+++ b/tests/unit/-debug/type-test.js
@@ -34,7 +34,7 @@ test('it works with classes', function(assert) {
 
   assert.throws(() => {
     foo.set('bar', 2);
-  }, /bar expected value of type function Date()/)
+  }, /Foo#bar expected value of type function Date()/)
 });
 
 test('it works with a default value', function(assert) {
@@ -58,7 +58,7 @@ test('it throws if an incorrect value is provided', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /bar expected value of type string during 'init', but received: 2/);
+  }, /Foo#bar expected value of type string during 'init', but received: 2/);
 });
 
 test('it works with the class hierarchy', function(assert) {
@@ -80,11 +80,11 @@ test('it works with the class hierarchy', function(assert) {
 
   assert.throws(() => {
     Quix.create({ prop: 2 });
-  }, /prop expected value of type string during 'init', but received: 2/);
+  }, /Quix#prop expected value of type string during 'init', but received: 2/);
 
   assert.throws(() => {
     Quix.create({ anotherProp: 'val' });
-  }, /anotherProp expected value of type number during 'init', but received: val/);
+  }, /Quix#anotherProp expected value of type number during 'init', but received: 'val'/);
 });
 
 test('it throws if an incorrect default default value is provided', function(assert) {
@@ -97,7 +97,7 @@ test('it throws if an incorrect default default value is provided', function(ass
     }
 
     Foo.create();
-  }, /bar expected value of type string during 'init', but received: undefined/);
+  }, /Foo#bar expected value of type string during 'init', but received: undefined/);
 
   assert.throws(() => {
     // incorrect default
@@ -108,7 +108,7 @@ test('it throws if an incorrect default default value is provided', function(ass
     }
 
     Foo.create();
-  }, /bar expected value of type string during 'init', but received: 2/);
+  }, /Foo#bar expected value of type string during 'init', but received: 2/);
 });
 
 test('throws if the property is set to an incorrect type', function(assert) {
@@ -122,7 +122,7 @@ test('throws if the property is set to an incorrect type', function(assert) {
 
     let foo = Foo.create();
     foo.set('bar', 2);
-  }, /bar expected value of type string during 'set', but received: 2/);
+  }, /Foo#bar expected value of type string during 'set', but received: 2/);
 });
 
 test('it requires exactly one type argument', function(assert) {
@@ -200,7 +200,7 @@ test('it throws if types are required on an argument', function(assert) {
     }
 
     Foo.create();
-  }, /bar requires a type, add one using the @type decorator/);
+  }, /Foo#bar requires a type, add one using the @type decorator/);
 
   config['@ember-decorators/argument'].typeRequired = false;
 });
@@ -242,7 +242,7 @@ test('subtypes can be added to classes', function(assert) {
 
   assert.throws(() => {
     Bar.create({ prop: 123 });
-  }, /prop expected value of type string during 'init', but received: 123/);
+  }, /Bar#prop expected value of type string during 'init', but received: 123/);
 });
 
 test('subtypes cannot deviate from superclass type', function(assert) {
@@ -261,7 +261,7 @@ test('subtypes cannot deviate from superclass type', function(assert) {
 
   assert.throws(() => {
     Bar.create({ prop: '123' });
-  }, /prop expected value of type number during 'init', but received: 123/);
+  }, /Bar#prop expected value of type number during 'init', but received: '123'/);
 });
 
 test('typed values can be set to their own value', function(assert) {
@@ -319,12 +319,12 @@ test('typed value can be provided by computed', function(assert) {
   assert.throws(() => {
     bar.set('value', 'foo');
     bar.get('prop');
-  }, /prop expected value of type number during 'get', but received: foo/);
+  }, /Bar#prop expected value of type number during 'get', but received: 'foo'/);
 
   // Throws when set to incorrect value
   assert.throws(() => {
     bar.set('prop', 'foo');
-  }, /prop expected value of type number during 'set', but received: foo/);
+  }, /Bar#prop expected value of type number during 'set', but received: 'foo'/);
 });
 
 test('typed value can be provided by alias', function(assert) {
@@ -357,12 +357,12 @@ test('typed value can be provided by alias', function(assert) {
   assert.throws(() => {
     bar.set('value', 'foo');
     bar.get('prop');
-  }, /prop expected value of type number during 'get', but received: foo/);
+  }, /Bar#prop expected value of type number during 'get', but received: 'foo'/);
 
   // Throws when set to incorrect value
   assert.throws(() => {
     bar.set('prop', 'foo');
-  }, /prop expected value of type number during 'set', but received: foo/);
+  }, /Bar#prop expected value of type number during 'set', but received: 'foo'/);
 });
 
 test('typed value can be provided by native getter/setter', function(assert) {
@@ -401,12 +401,12 @@ test('typed value can be provided by native getter/setter', function(assert) {
   assert.throws(() => {
     bar.value = 'foo';
     bar.get('prop');
-  }, /prop expected value of type number during 'get', but received: foo/);
+  }, /Bar#prop expected value of type number during 'get', but received: 'foo'/);
 
   // Throws when set to incorrect value
   assert.throws(() => {
     bar.set('prop', 'foo');
-  }, /prop expected value of type number during 'set', but received: foo/);
+  }, /Bar#prop expected value of type number during 'set', but received: 'foo'/);
 });
 
 test('typed value can be watched', function(assert) {

--- a/tests/unit/-debug/types/array-of-test.js
+++ b/tests/unit/-debug/types/array-of-test.js
@@ -27,7 +27,7 @@ test('it throws if array items do not match', function(assert) {
     }
 
     Foo.create({ bar: ['baz', 2] });
-  }, /bar expected value of type arrayOf\(string\) during 'init', but received: baz,2/);
+  }, /Foo#bar expected value of type arrayOf\(string\) during 'init', but received: baz,2/);
 });
 
 test('it throws if type does not match', function(assert) {
@@ -39,7 +39,7 @@ test('it throws if type does not match', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /bar expected value of type arrayOf\(string\) during 'init', but received: 2/);
+  }, /Foo#bar expected value of type arrayOf\(string\) during 'init', but received: 2/);
 });
 
 test('it throws if incorrect number of items passed in', function(assert) {

--- a/tests/unit/-debug/types/optional-test.js
+++ b/tests/unit/-debug/types/optional-test.js
@@ -30,11 +30,11 @@ test('it throws if type does not match', function(assert) {
 
   assert.throws(() => {
     Foo.create({ bar: 2 });
-  }, /bar expected value of type optional\(string\) during 'init', but received: 2/);
+  }, /Foo#bar expected value of type optional\(string\) during 'init', but received: 2/);
 
   assert.throws(() => {
     Foo.create({ bar: new Date() });
-  }, /bar expected value of type optional\(string\) during 'init', but received/);
+  }, /Foo#bar expected value of type optional\(string\) during 'init', but received/);
 });
 
 test('it requires primitive types or classes', function(assert) {

--- a/tests/unit/-debug/types/predefined-test.js
+++ b/tests/unit/-debug/types/predefined-test.js
@@ -36,7 +36,7 @@ function predefinedTypeTest(testType, subtypes) {
       } else {
         assert.throws(() => {
           Foo.create({ foo: primitives[primitive] });
-        }, /foo expected value of type/)
+        }, /Foo#foo expected value of type/)
       }
     }
   });

--- a/tests/unit/-debug/types/shape-of-test.js
+++ b/tests/unit/-debug/types/shape-of-test.js
@@ -27,7 +27,7 @@ test('it throws if array items do not match', function(assert) {
     }
 
     Foo.create({ bar: { qux: 'baz' } });
-  }, /bar expected value of type shapeOf\({foo:string}\) during 'init', but received: \[object Object\]/);
+  }, /Foo#bar expected value of type shapeOf\({foo:string}\) during 'init', but received: \[object Object\]/);
 });
 
 test('it throws if type does not match', function(assert) {
@@ -39,7 +39,7 @@ test('it throws if type does not match', function(assert) {
     }
 
     Foo.create({ bar: 2 });
-  }, /bar expected value of type shapeOf\({foo:string}\) during 'init', but received: 2/);
+  }, /Foo#bar expected value of type shapeOf\({foo:string}\) during 'init', but received: 2/);
 });
 
 test('it throws if non-object passed in', function(assert) {

--- a/tests/unit/-debug/types/union-of-test.js
+++ b/tests/unit/-debug/types/union-of-test.js
@@ -29,11 +29,11 @@ test('it throws if type does not match', function(assert) {
 
   assert.throws(() => {
     Foo.create({ bar: null });
-  }, /bar expected value of type unionOf\(string,undefined\) during 'init', but received: null/);
+  }, /Foo#bar expected value of type unionOf\(string,undefined\) during 'init', but received: null/);
 
   assert.throws(() => {
     Foo.create({ bar: new Date() });
-  }, /bar expected value of type unionOf\(string,undefined\) during 'init', but received/);
+  }, /Foo#bar expected value of type unionOf\(string,undefined\) during 'init', but received/);
 });
 
 test('it requires primitive types or classes', function(assert) {


### PR DESCRIPTION
This PR fixes a regression in error messages and improves them
in general by using the actual class name instead of the
value

Fixes #55