### PR TITLE
Add `oneOf` type validator

### DIFF
--- a/addon/-debug/helpers/one-of.js
+++ b/addon/-debug/helpers/one-of.js
@@ -1,0 +1,11 @@
+import { assert } from '@ember/debug';
+import { makeValidator } from '../utils/validators';
+
+export default function oneOf(...list) {
+  assert(`The 'oneOf' helper must receive at least one argument`, arguments.length >= 1);
+  assert(`The 'oneOf' helper must receive arguments of strings, received: ${list}`, list.every(item => typeof item === 'string'));
+
+  return makeValidator(`oneOf(${list.join()})`, (value) => {
+    return list.includes(value);
+  });
+}

--- a/addon/-debug/index.js
+++ b/addon/-debug/index.js
@@ -6,6 +6,7 @@ export { default as arrayOf } from './helpers/array-of';
 export { default as shapeOf } from './helpers/shape-of';
 export { default as unionOf } from './helpers/union-of';
 export { default as optional } from './helpers/optional';
+export { default as oneOf } from './helpers/one-of';
 
 export { MutabilityError as MutabilityError } from './errors';
 export { RequiredFieldError as RequiredFieldError } from './errors';

--- a/addon/type.js
+++ b/addon/type.js
@@ -4,3 +4,4 @@ export { arrayOf as arrayOf } from '@ember-decorators/argument/-debug';
 export { shapeOf as shapeOf } from '@ember-decorators/argument/-debug';
 export { unionOf as unionOf } from '@ember-decorators/argument/-debug';
 export { optional as optional } from '@ember-decorators/argument/-debug';
+export { oneOf as oneOf } from '@ember-decorators/argument/-debug';

--- a/index.js
+++ b/index.js
@@ -103,7 +103,8 @@ module.exports = {
                   'optional',
                   'arrayOf',
                   'shapeOf',
-                  'unionOf'
+                  'unionOf',
+                  'oneOf'
                 ],
                 '@ember-decorators/argument/types': [
                   'Action',

--- a/tests/unit/-debug/types/one-of-test.js
+++ b/tests/unit/-debug/types/one-of-test.js
@@ -1,0 +1,55 @@
+import EmberObject from '@ember/object';
+import { test, module } from 'qunit';
+
+import { argument } from '@ember-decorators/argument';
+import { type, oneOf } from '@ember-decorators/argument/type';
+
+module('oneOf');
+
+test('it works', function(assert) {
+  assert.expect(0);
+
+  class Foo extends EmberObject {
+    @type(oneOf('red', 'blue', 'green'))
+    @argument
+    bar;
+  }
+
+  Foo.create({ bar: 'blue' });
+});
+
+test('it throws if arguments do not match', function(assert) {
+  assert.throws(() => {
+    class Foo extends EmberObject {
+      @type(oneOf('red', 'blue', 'green'))
+      @argument
+      bar;
+    }
+
+    Foo.create({ bar: 'magenta' });
+  }, /Foo#bar expected value of type oneOf\(red,blue,green\) during 'init', but received: 'magenta'/);
+});
+
+test('it throws if non-string passed in', function(assert) {
+  assert.throws(() => {
+    class Foo extends EmberObject {
+      @type(oneOf(true))
+      @argument
+      bar;
+    }
+
+    Foo.create({ bar: 'peanut butter' });
+  }, /The 'oneOf' helper must receive arguments of strings, received: true/);
+});
+
+test('it throws if incorrect number of items passed in', function(assert) {
+  assert.throws(() => {
+    class Foo extends EmberObject {
+      @type(oneOf())
+      @argument
+      bar;
+    }
+
+    Foo.create({ bar: 'grapes' });
+  }, /The 'oneOf' helper must receive at least one argument/);
+});


### PR DESCRIPTION
This pull request closes #30 by adding a simple `oneOf` validator:

```javascript
  class Foo extends EmberObject {
    @type(oneOf('red', 'blue', 'green'))
    @argument
    bar;
  }
```

Tests closely mirror `shapeOf`.
