### PR TITLE
[bugfix] Ensure Angle Bracket invocation works

### DIFF
--- a/addon/-debug/validated-component.js
+++ b/addon/-debug/validated-component.js
@@ -17,7 +17,8 @@ const whitelist = {
   classNames: true,
   id: true,
   isVisible: true,
-  tagName: true
+  tagName: true,
+  __ANGLE_ATTRS__: true
 };
 
 if (gte('1.13.0')) {


### PR DESCRIPTION
Adds a private argument key that is used by the angle bracket invocation
polyfill so argument validations don't throw an error.