### PR TITLE
fix `optional` helper

### DIFF
--- a/addon/-debug/helpers/optional.js
+++ b/addon/-debug/helpers/optional.js
@@ -14,6 +14,6 @@ export default function optional(type) {
   assert(`Passsing 'undefined' to the 'optional' helper does not make sense.`, validatorDesc !== 'undefined');
 
   return makeValidator(`optional(${validator})`, (value) =>
-    validator(value) || nullValidator(value) || undefinedValidator(value)
+    nullValidator(value) || undefinedValidator(value) || validator(value)
   );
 }

--- a/tests/unit/-debug/types/shape-of-test.js
+++ b/tests/unit/-debug/types/shape-of-test.js
@@ -2,7 +2,7 @@ import EmberObject from '@ember/object';
 import { test, module } from 'qunit';
 
 import { argument } from '@ember-decorators/argument';
-import { type, shapeOf } from '@ember-decorators/argument/type';
+import { type, shapeOf, optional } from '@ember-decorators/argument/type';
 
 module('shapeOf');
 
@@ -16,6 +16,18 @@ test('it works', function(assert) {
   }
 
   Foo.create({ bar: { foo: 'baz' } });
+});
+
+test('it works with optional', function(assert) {
+  assert.expect(0);
+
+  class Foo extends EmberObject {
+    @type(optional(shapeOf({ foo: 'string' })))
+    @argument
+    bar;
+  }
+
+  Foo.create({ bar: null });
 });
 
 test('it throws if array items do not match', function(assert) {


### PR DESCRIPTION
Basically the problem I was facing was that using, for example, `@type(optional(shapeOf({ then: Function })))` was throwing if I passed in `null or undefined`, which shouldn't because it was marked as optional.

I fixed this by testing null and undefined first and only then testing the actual type that is passed to `optional`. This change made the test pass.

Let me know if you need anything else from me.