### PR TITLE
Use ember's isArray on arrayOf validator

### DIFF
--- a/addon/-debug/helpers/array-of.js
+++ b/addon/-debug/helpers/array-of.js
@@ -1,5 +1,6 @@
 import { assert } from '@ember/debug';
 import { resolveValidator, makeValidator } from '../utils/validators';
+import { isArray } from '@ember/array';
 
 export default function arrayOf(type) {
   assert(`The 'arrayOf' helper must receive exactly one type. Use the 'unionOf' helper to create a union type.`, arguments.length === 1);
@@ -7,7 +8,7 @@ export default function arrayOf(type) {
   const validator = resolveValidator(type);
 
   return makeValidator(`arrayOf(${validator})`, (value) => {
-    return Array.isArray(value) && value.every(validator);
+    return isArray(value) && value.every(validator);
   });
 }
 


### PR DESCRIPTION
I created this pull request as a way to start a suggestion/question.

So, I needed to validate that a certain argument was an array. However, when I tried to use this with the return value of an ember-data's `store.findAll` I got an error because that's a `DS.RecordArray` and not a native array.

Would it make sense to use ember's `isArray` function to detect arrays to allow a better interoperability with ember arrays?