### PR TITLE
feature: Allow user to expand attribute whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,54 @@ ember install @ember-decorators/argument
 
 ## Configuration
 
-### `enableCodeStripping`
+### Run-Time
+
+#### `argumentWhitelist`
+
+**Type**: `Array` or `Object` | **Default**: `[]`
+
+Once `@argument` has been applied to a component, unexpected arguments passed to a component will result in an error. In order to work with some addons that expect you to provide additional arguments to your components, you can whitelist additional properties that should be ignored.
+
+When provided an array of `string`, those exact properties will be added to the whitelist.
+
+To provide a more flexible solution, you can also provide an object with the following structure:
+
+```javascript
+shapeOf({
+  // Whitelist any string starting with one of these values
+  startsWith: optional(arrayOf('string'))
+  // Whitelist any string ending with one of these values
+  endsWith: optional(arrayOf('string'))
+  // Whitelist any string that include one of these values anywhere
+  includes: optional(arrayOf('string'))
+  // Whitelist any string that exactly matches one of these values
+  matches: optional(arrayOf('string'))
+})
+```
+
+##### Example
+
+```javascript
+// config/environment.js
+module.exports = function(environment) {
+  let ENV = {
+    // ...
+    '@ember-decorators/argument': {
+      argumentWhitelist: {
+        startsWith: ['hotReloadCUSTOM']
+      }
+    }
+  };
+
+  // ...
+
+  return ENV;
+};
+```
+
+### Build-Time
+
+#### `enableCodeStripping`
 
 **Type**: `Boolean` | **Default**: `true`
 
@@ -108,7 +155,7 @@ By default most of the code provided by this addon is removed in a Production bu
 
 However, if the process seems buggy or you want the validation in production, setting this flag to `false` will prevent any code from being removed.
 
-#### Example
+##### Example
 
 ```javascript
 // ember-cli-build.js

--- a/addon/-private/config.js
+++ b/addon/-private/config.js
@@ -1,0 +1,37 @@
+import { getWithDefault } from '@ember/object';
+import fullApplicationConfig from 'ember-get-config';
+
+const addonConfig = getWithDefault(
+  fullApplicationConfig,
+  '@ember-decorators/argument',
+  {}
+);
+
+const argumentWhitelistConfig = getWithDefault(
+  addonConfig,
+  'argumentWhitelist',
+  []
+);
+
+export function extractArgumentWhitelist(config) {
+  config = config || [];
+
+  return Array.isArray(config)
+    ? config
+    : [
+        ...getWithDefault(config, 'startsWith', []).map(
+          startsWith => new RegExp(`^${startsWith}`)
+        ),
+        ...getWithDefault(config, 'endsWith', []).map(
+          endsWith => new RegExp(`${endsWith}$`)
+        ),
+        ...getWithDefault(config, 'includes', []).map(
+          includes => new RegExp(includes)
+        ),
+        ...getWithDefault(config, 'matches', [])
+      ];
+}
+
+export const argumentWhitelist = extractArgumentWhitelist(
+  argumentWhitelistConfig
+);

--- a/addon/-private/extensions/prevent-additional-arguments.js
+++ b/addon/-private/extensions/prevent-additional-arguments.js
@@ -1,21 +1,23 @@
 import Component from '@ember/component';
 import { assert } from '@ember/debug';
 
+import { argumentWhitelist } from '../config';
 import { getValidationsFor } from '../validations-for';
 import { isExtensionOf } from '../utils/object';
 
 const HAS_EXTENSION = new WeakSet();
 
-const whitelist = {
-  ariaRole: true,
-  class: true,
-  classNames: true,
-  id: true,
-  isVisible: true,
-  tagName: true,
-  target: true,
-  __ANGLE_ATTRS__: true
-};
+const whitelist = [
+  'ariaRole',
+  'class',
+  'classNames',
+  'id',
+  'isVisible',
+  'tagName',
+  'target',
+  '__ANGLE_ATTRS__',
+  ...argumentWhitelist
+];
 
 export function needsExtension(klass) {
   return isExtensionOf(klass, Component);
@@ -47,12 +49,17 @@ export function withExtension(klass) {
         binding => binding.split(':')[0]
       );
 
+      const expectedArguments = [
+        ...attributes,
+        ...classNames,
+        ...Object.keys(validations),
+        ...whitelist
+      ];
+
       for (let key in this.attrs) {
-        const isValidArgOrAttr =
-          key in validations ||
-          key in whitelist ||
-          attributes.indexOf(key) !== -1 ||
-          classNames.indexOf(key) !== -1;
+        const isValidArgOrAttr = expectedArguments.some(matcher =>
+          key.match(matcher)
+        );
 
         assert(
           `Attempted to assign the argument '${key}' on an instance of ${

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "broccoli-funnel": "^2.0.1",
     "debug": "^4.1.0",
     "ember-cli-babel": "^7.1.4",
-    "ember-cli-version-checker": "^2.0.0"
+    "ember-cli-version-checker": "^2.0.0",
+    "ember-get-config": "^0.2.4"
   },
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^3.1.0",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -20,6 +20,13 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+
+    '@ember-decorators/argument': {
+      argumentWhitelist: {
+        matches: ['exact-attribute'],
+        startsWith: ['hotReloadCUSTOM']
+      }
     }
   };
 

--- a/tests/integration/component-behavior-test.js
+++ b/tests/integration/component-behavior-test.js
@@ -124,4 +124,19 @@ module('Integration | Component Behavior', function(hooks) {
       }}
     `);
   });
+
+  test('does not assert on attributes added to the whitelist', async function(assert) {
+    assert.expect(0);
+
+    class FooComponent extends ComponentWithArgument {}
+
+    this.owner.register('component:foo-component', FooComponent);
+
+    await render(hbs`
+      {{foo-component
+        exact-attribute='something'
+        hotReloadCUSTOMName='something'
+      }}
+    `);
+  });
 });

--- a/tests/integration/component-behavior-test.js
+++ b/tests/integration/component-behavior-test.js
@@ -5,15 +5,20 @@ import hbs from 'htmlbars-inline-precompile';
 import Component from '@ember/component';
 
 import { argument } from '@ember-decorators/argument';
+import { optional } from '@ember-decorators/argument/types';
 import { attribute, className } from '@ember-decorators/component';
 
 import waitForError from '../helpers/wait-for-error';
+
+class ComponentWithArgument extends Component {
+  @argument(optional('string')) someProp;
+}
 
 module('Integration | Component Behavior', function(hooks) {
   setupRenderingTest(hooks);
 
   test('asserts on args which are not the correct type', async function(assert) {
-    class FooComponent extends Component {
+    class FooComponent extends ComponentWithArgument {
       @argument('string') foo;
     }
 
@@ -31,7 +36,7 @@ module('Integration | Component Behavior', function(hooks) {
   });
 
   test('asserts on args which are not defined', async function(assert) {
-    class FooComponent extends Component {
+    class FooComponent extends ComponentWithArgument {
       @argument('number') foo;
     }
 
@@ -51,7 +56,7 @@ module('Integration | Component Behavior', function(hooks) {
   test('does not assert on args which are defined', async function(assert) {
     assert.expect(0);
 
-    class FooComponent extends Component {
+    class FooComponent extends ComponentWithArgument {
       @argument('number') foo;
     }
 
@@ -63,7 +68,7 @@ module('Integration | Component Behavior', function(hooks) {
   test('does not assert on attributes which are defined', async function(assert) {
     assert.expect(0);
 
-    class FooComponent extends Component {
+    class FooComponent extends ComponentWithArgument {
       @attribute foo;
     }
 
@@ -75,7 +80,7 @@ module('Integration | Component Behavior', function(hooks) {
   test('does not assert on classNames which are defined', async function(assert) {
     assert.expect(0);
 
-    class FooComponent extends Component {
+    class FooComponent extends ComponentWithArgument {
       @className foo;
     }
 
@@ -87,7 +92,7 @@ module('Integration | Component Behavior', function(hooks) {
   test('does not assert on classNames or attributes which are defined dynamically', async function(assert) {
     assert.expect(0);
 
-    class FooComponent extends Component {
+    class FooComponent extends ComponentWithArgument {
       constructor() {
         super(...arguments);
 
@@ -104,7 +109,7 @@ module('Integration | Component Behavior', function(hooks) {
   test('does not assert on whitelisted arguments and attributes', async function(assert) {
     assert.expect(0);
 
-    class FooComponent extends Component {}
+    class FooComponent extends ComponentWithArgument {}
 
     this.owner.register('component:foo-component', FooComponent);
 

--- a/tests/unit/private/config-test.js
+++ b/tests/unit/private/config-test.js
@@ -1,0 +1,78 @@
+import { module, test } from 'qunit';
+import {
+  argumentWhitelist,
+  extractArgumentWhitelist
+} from '@ember-decorators/argument/-private/config';
+
+module('Unit | Utility | -private/config', function() {
+  module('argumentWhitelist', function() {
+    test('it resolves the application configuration', function(assert) {
+      assert.deepEqual(
+        argumentWhitelist,
+        [/^hotReloadCUSTOM/, 'exact-attribute'],
+        'Matches the dummy configuration'
+      );
+    });
+  });
+
+  module('extractArgumentWhitelist', function() {
+    test('no configuration', function(assert) {
+      assert.deepEqual(extractArgumentWhitelist({}), [], 'An empty object');
+      assert.deepEqual(extractArgumentWhitelist([]), [], 'An empty array');
+      assert.deepEqual(extractArgumentWhitelist(undefined), [], '`undefined`');
+      assert.deepEqual(extractArgumentWhitelist(null), [], '`null`');
+    });
+
+    module('an array', function() {
+      test('an array of strings', function(assert) {
+        assert.deepEqual(
+          extractArgumentWhitelist(['foo', 'bar']),
+          ['foo', 'bar'],
+          'It returns the array of strings'
+        );
+      });
+    });
+
+    module('an object with semantic sets of matchers', function() {
+      test('.startsWith', function(assert) {
+        assert.deepEqual(
+          extractArgumentWhitelist({
+            startsWith: ['foo']
+          }),
+          [/^foo/],
+          'Elements are turned into the right regex'
+        );
+      });
+
+      test('.endsWith', function(assert) {
+        assert.deepEqual(
+          extractArgumentWhitelist({
+            endsWith: ['foo']
+          }),
+          [/foo$/],
+          'Elements are turned into the right regex'
+        );
+      });
+
+      test('.includes', function(assert) {
+        assert.deepEqual(
+          extractArgumentWhitelist({
+            includes: ['foo']
+          }),
+          [/foo/],
+          'Elements are turned into the right regex'
+        );
+      });
+
+      test('.matches', function(assert) {
+        assert.deepEqual(
+          extractArgumentWhitelist({
+            matches: ['foo']
+          }),
+          ['foo'],
+          'Elements are passed through as strings'
+        );
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1587,6 +1587,13 @@ babel-plugin-ember-modules-api-polyfill@^2.5.0:
   dependencies:
     ember-rfc176-data "^0.3.5"
 
+babel-plugin-ember-modules-api-polyfill@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.6.0.tgz#9524a65ef0c31ee82536a19c243fbaec1b977cbb"
+  integrity sha512-BSbLv3+ju1mcUUoPe7vPJgnGawrNxp6LfFBRHlNOKeMlQlml9Wo2MRRUrbpNDlmVc761xSKj8+cde7R0Lwpq7g==
+  dependencies:
+    ember-rfc176-data "^0.3.6"
+
 babel-plugin-espower@^2.3.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-espower/-/babel-plugin-espower-2.4.0.tgz#9f92c080e9adfe73f69baed7ab3e24f649009373"
@@ -2332,6 +2339,14 @@ broccoli-debug@^0.6.5:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
+broccoli-file-creator@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz#27f1b25b1b00e7bb7bf3d5d7abed5f4d5388df4d"
+  integrity sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==
+  dependencies:
+    broccoli-plugin "^1.1.0"
+    mkdirp "^0.5.1"
+
 broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
@@ -2509,7 +2524,7 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-plugin@^1.3.1:
+broccoli-plugin@^1.1.0, broccoli-plugin@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz#a26315732fb99ed2d9fb58f12a1e14e986b4fabd"
   integrity sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==
@@ -3564,6 +3579,25 @@ ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1:
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
 
+ember-cli-babel@^6.3.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
+  integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.5.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
+    semver "^5.5.0"
+
 ember-cli-babel@^7.1.3, ember-cli-babel@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.1.4.tgz#5f2b6ba2156d8dce2681aea92689b57ffbc71ccb"
@@ -3862,6 +3896,14 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-get-config@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
+  integrity sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^6.3.0"
+
 ember-load-initializers@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.1.0.tgz#4edacc0f3a14d9f53d241ac3e5561804c8377978"
@@ -3920,6 +3962,11 @@ ember-rfc176-data@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.5.tgz#f630e550572c81a5e5c7220f864c0f06eee9e977"
   integrity sha512-5NfL1iTkIQDYs16/IZ7/jWCEglNsUrigLelBkBMsNcib9T3XzQwmhhVTjoSsk66s57LmWJ1bQu+2c1CAyYCV7A==
+
+ember-rfc176-data@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.6.tgz#7138db8dfccec39c9a832adfbd4c49d670028907"
+  integrity sha512-kPY94VCukPUPj+/6sZ9KvphD42KnpX2IS31p5z07OFVIviDogR0cQuld5c7Irzfgq7a0YACj0HlToROFn7dLYQ==
 
 ember-router-generator@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
As suggested by #89, since many addons expect users to define properties on their components, we should allow the user to expand the whitelist that we use internally to keep track of expected attributes that are not defined arguments.

I originally just wanted to support an array of Regular Expressions, but that doesn't work with `ember-get-config` and I couldn't come up with an alternate means for configuring this that I was comfortable with.

Thus, the API ended up being separate arrays of patterns to start/end/include, plus a simplified version for exact values to match against.

One downside here is that we now have some configuration in `config/environment` and some in `ember-cli-build`. I don't think this is too big of a deal, though, as one is for the run-time behavior and the other is for the build-time behavior.

Closes #89 