### PR TITLE
fix: only add `babel-plugin-filter-imports` one time

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const Funnel = require('broccoli-funnel');
 const VersionChecker = require('ember-cli-version-checker');
 const log = require('debug')('ember-decorators:argument');
 
+const FILTER_IMPORTS_LABEL = 'filter-imports:@ember-decorators/argument';
+
 function isProductionEnv() {
   return /production/.test(process.env.EMBER_ENV);
 }
@@ -57,26 +59,33 @@ module.exports = {
   },
 
   stripImports(babelOptions) {
-    babelOptions.plugins.push([
-      require.resolve('babel-plugin-filter-imports'),
-      {
-        imports: {
-          '@ember-decorators/argument': ['argument'],
-          '@ember-decorators/argument/types': [
-            'Any',
-            'arrayOf',
-            'optional',
-            'oneOf',
-            'shapeOf',
-            'unionOf',
-            'Action',
-            'ClassicAction',
-            'Element',
-            'Node'
-          ]
-        }
-      }
-    ]);
+    const alreadyHasPlugin = babelOptions.plugins
+      .filter(definition => Array.isArray(definition))
+      .some(definition => definition[2] === FILTER_IMPORTS_LABEL);
+
+    if (!alreadyHasPlugin) {
+      babelOptions.plugins.push([
+        require.resolve('babel-plugin-filter-imports'),
+        {
+          imports: {
+            '@ember-decorators/argument': ['argument'],
+            '@ember-decorators/argument/types': [
+              'Any',
+              'arrayOf',
+              'optional',
+              'oneOf',
+              'shapeOf',
+              'unionOf',
+              'Action',
+              'ClassicAction',
+              'Element',
+              'Node'
+            ]
+          }
+        },
+        'filter-imports:@ember-decorators/argument'
+      ]);
+    }
   },
 
   included(app) {


### PR DESCRIPTION
This ensures that a user does not get an error if they have this add-on in their `dependency` tree multiple times.

I discovered this after upgrading out app to use Babel 7 this week. When we went to deploy today, we got the following build error:

```
Duplicate plugin/preset detected.
If you'd like to use two separate instances of a plugin,
they need separate names, e.g.

  plugins: [
    ['some-plugin', {}],
    ['some-plugin', {}, 'some unique name'],
  ]
```

Without checking for an existing instance first, about 6 versions of `babel-plugin-filter-imports` were being supplied by `ember-decorators/argument` due to the way this add-on installed in many internal add-ons that are installed by the main app.

Unfortunately, the `hasPlugin` and `addPlugin` logic from `ember-cli-babel-plugin-helpers` doesn't really apply here, because we don't want to disallow other addons from supplying their own configurations of `babel-plugin-filter-imports`.