### PR TITLE
fix: handle null target instances passed to getPropertyDescriptor

### DIFF
--- a/addon/-private/utils/object.js
+++ b/addon/-private/utils/object.js
@@ -7,7 +7,7 @@
  * @return {Descriptor|undefined}
  */
 export function getPropertyDescriptor(target, property) {
-  if (target === undefined) return;
+  if (target === undefined || target === null) return;
 
   return (
     Object.getOwnPropertyDescriptor(target, property) ||

--- a/addon/-private/wrap-field.js
+++ b/addon/-private/wrap-field.js
@@ -154,6 +154,7 @@ export function wrapField(klass, instance, validations, keyName) {
     let desc = getPropertyDescriptor(instance, keyName);
 
     if (
+      typeof desc === 'object' &&
       (typeof desc.get === 'function' || typeof desc.set === 'function') &&
       !isMandatorySetter(desc.set)
     ) {


### PR DESCRIPTION
This PR seeks to fix https://github.com/ember-decorators/argument/issues/98. 

[-private/utils/object.js#L10](https://github.com/willviles/argument/blob/077b2940694cb35627802b5b99b12ab79eed81c3/addon/-private/utils/object.js#L10) was erroring because `target` passed to `getPropertyDescriptor` was in some cases `null`, not `undefined`.

```js
export function getPropertyDescriptor(target, property) {
  if (target === undefined) return;
  // target = null...
  return (
    Object.getOwnPropertyDescriptor(target, property) ||
    getPropertyDescriptor(Object.getPrototypeOf(target), property)
  );
}
```